### PR TITLE
Add viewroll and viewmodel bob tilt

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -88,6 +88,8 @@ extern client_sprite_t *GetSpriteList(client_sprite_t *pList, const char *psz, i
 extern cvar_t *sensitivity;
 cvar_t *cl_lw = NULL;
 cvar_t *cl_righthand = nullptr;
+cvar_t *cl_viewrollangle;
+cvar_t *cl_viewrollspeed;
 
 void ShutdownInput (void);
 
@@ -452,6 +454,8 @@ void CHud :: Init( void )
 
 	// VGUI Menus
 	HOOK_MESSAGE( VGUIMenu );
+	cl_viewrollangle = CVAR_CREATE ( "cl_viewrollangle", "0.65", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
+	cl_viewrollspeed = CVAR_CREATE ( "cl_viewrollspeed", "300", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 
 	HOOK_MESSAGE( CheatCheck );
 	HOOK_MESSAGE( WhString );

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -454,7 +454,7 @@ void CHud :: Init( void )
 
 	// VGUI Menus
 	HOOK_MESSAGE( VGUIMenu );
-	cl_viewrollangle = CVAR_CREATE ( "cl_viewrollangle", "0.65", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
+	cl_viewrollangle = CVAR_CREATE ( "cl_viewrollangle", "0", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 	cl_viewrollspeed = CVAR_CREATE ( "cl_viewrollspeed", "300", FCVAR_CLIENTDLL | FCVAR_ARCHIVE );
 
 	HOOK_MESSAGE( CheatCheck );

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -411,7 +411,7 @@ void V_CalcViewRoll ( struct ref_params_s *pparams )
 	viewentity = gEngfuncs.GetEntityByIndex( pparams->viewentity );
 	if ( !viewentity )
 		return;
-	pparams->viewangles[ROLL] = V_CalcRoll (pparams->viewangles, pparams->simvel, cl_viewrollangle->value, cl_viewrollspeed->value ) * 4;
+	pparams->viewangles[ROLL] += V_CalcRoll (pparams->viewangles, pparams->simvel, cl_viewrollangle->value, cl_viewrollspeed->value ) * 4;
 
 	side = V_CalcRoll ( viewentity->angles, pparams->simvel, pparams->movevars->rollangle, pparams->movevars->rollspeed );
 

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -401,6 +401,8 @@ V_CalcViewRoll
 Roll is induced by movement and damage
 ==============
 */
+extern cvar_t *cl_viewrollangle;
+extern cvar_t *cl_viewrollspeed;
 void V_CalcViewRoll ( struct ref_params_s *pparams )
 {
 	float		side;
@@ -409,6 +411,7 @@ void V_CalcViewRoll ( struct ref_params_s *pparams )
 	viewentity = gEngfuncs.GetEntityByIndex( pparams->viewentity );
 	if ( !viewentity )
 		return;
+	pparams->viewangles[ROLL] = V_CalcRoll (pparams->viewangles, pparams->simvel, cl_viewrollangle->value, cl_viewrollspeed->value ) * 4;
 
 	side = V_CalcRoll ( viewentity->angles, pparams->simvel, pparams->movevars->rollangle, pparams->movevars->rollspeed );
 
@@ -661,6 +664,7 @@ void V_CalcNormalRefdef ( struct ref_params_s *pparams )
 	view->angles[YAW]   -= bob * 0.5;
 	view->angles[ROLL]  -= bob * 1;
 	view->angles[PITCH] -= bob * 0.3;
+	VectorCopy(view->angles, view->curstate.angles);
 
 	// pushing the view origin down off of the same X/Z plane as the ent's origin will give the
 	// gun a very nice 'shifting' effect when the player looks up/down. If there is a problem


### PR DESCRIPTION
Viewroll and viewmodel bob tilt was loved by many players at Half-Life's release but was removed from the engine in version 1.1.1.0. I think that adding this would attract more players to AG as it brings a removed old-school feature back.

Video demonstration:
https://www.youtube.com/watch?v=Yf2YzRkdVOU