### PR TITLE
Add GitHub Actions CI for Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    paths-ignore:
+      - .travis.yml
+      - appveyor.yml
+      - filecopy.bat
+      - LICENSE*
+      - 'README.md'
+  pull_request:
+    paths-ignore:
+      - .travis.yml
+      - appveyor.yml
+      - filecopy.bat
+      - LICENSE*
+      - 'README.md'
+
+jobs:
+  build-windows:
+    runs-on: vs2017-win2016
+    strategy:
+      fail-fast: false
+      matrix:
+        configuration: [Release, Debug]
+        toolset: [v141_xp, v141]
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+    - name: Prepare for build
+      run: |
+        mkdir build
+        cd build
+        cmake -T ${{ matrix.toolset }} ..
+    - name: Build
+      working-directory: build
+      run: cmake --build . --config ${{ matrix.configuration }}
+    - name: Upload artifact
+      if: matrix.toolset == 'v141_xp'
+      uses: actions/upload-artifact@v1
+      with:
+        name: openag-${{ runner.os }}-${{ matrix.configuration }}
+        path: build\${{ matrix.configuration }}\client.dll

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ﻿OpenAG
 ======================
+[![Build Status](https://github.com/Margen67/OpenAG/workflows/CI/badge.svg?branch=master)](https://github.com/YaLTeR/OpenAG/actions?query=branch:master)
 [![Build Status](https://travis-ci.org/YaLTeR/OpenAG.svg?branch=master)](https://travis-ci.org/YaLTeR/OpenAG)
 [![Build Status](https://ci.appveyor.com/api/projects/status/o758yugwuavrt9qi?svg=true)](https://ci.appveyor.com/project/YaLTeR/openag)
 [![Chat on Discord](https://discordapp.com/api/guilds/252168904359542784/widget.png)](https://discord.gg/jCYhYNH)


### PR DESCRIPTION
Windows only for now since macOS and Linux fail: https://github.com/Margen67/OpenAG/runs/461881133

Only has artifacts for the `v141_xp` toolset.