### PR TITLE
Add a cvar to fix viewheight on newer HLSDK

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -482,6 +482,7 @@ void CHud :: Init( void )
 	m_pCvarDraw = CVAR_CREATE( "hud_draw", "1", FCVAR_ARCHIVE );
 	m_pCvarDrawDeathNoticesAlways = CVAR_CREATE( "cl_draw_deathnotices_always", "0", FCVAR_ARCHIVE );
 	m_pCvarAutostop = CVAR_CREATE("cl_autostop", "0", FCVAR_ARCHIVE);
+	m_pCvarViewheightMode = CVAR_CREATE("cl_viewheight_mode", "0", FCVAR_ARCHIVE);
 	m_pCvarColor = CVAR_CREATE( "hud_color", "", FCVAR_ARCHIVE );
 	cl_lw = gEngfuncs.pfnGetCvarPointer( "cl_lw" );
 

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -587,6 +587,7 @@ public:
 	cvar_t	*m_pCvarDraw;
 	cvar_t	*m_pCvarDrawDeathNoticesAlways;
 	cvar_t	*m_pCvarAutostop;
+	cvar_t	*m_pCvarViewheightMode;
 
 	int m_iFontHeight;
 

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -1310,6 +1310,14 @@ void V_GetInEyePos(int target, float * origin, float * angles )
 
 	angles[PITCH]*=-3.0f;	// see CL_ProcessEntityUpdate()
 
+	if (gHUD.m_pCvarViewheightMode->value != 0.0f)
+	{
+		// In the latest HLSDK some observer stuff is performed serverside which ends up
+		// adding some extra viewheight here when spectating in first person mode, so use
+		// cl_viewheight_mode 1 to avoid the extra viewheight
+		return;
+	}
+
 	if ( ent->curstate.solid == SOLID_NOT )
 	{
 		angles[ROLL] = 80;	// dead view angle

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -1310,14 +1310,6 @@ void V_GetInEyePos(int target, float * origin, float * angles )
 
 	angles[PITCH]*=-3.0f;	// see CL_ProcessEntityUpdate()
 
-	if (gHUD.m_pCvarViewheightMode->value != 0.0f)
-	{
-		// In the latest HLSDK some observer stuff is performed serverside which ends up
-		// adding some extra viewheight here when spectating in first person mode, so use
-		// cl_viewheight_mode 1 to avoid the extra viewheight
-		return;
-	}
-
 	if ( ent->curstate.solid == SOLID_NOT )
 	{
 		angles[ROLL] = 80;	// dead view angle
@@ -1511,7 +1503,25 @@ void V_CalcSpectatorRefdef ( struct ref_params_s * pparams )
 //		if ( gEngfuncs.IsSpectateOnly() )
 //#endif
 		{
-			V_GetInEyePos( g_iUser2, pparams->simorg, pparams->cl_viewangles );
+			if ( gHUD.m_pCvarViewheightMode->value != 0.0f && ( gHUD.m_Spectator.m_pip->value == INSET_IN_EYE || g_iUser1 == OBS_IN_EYE ) )
+			{
+				// In the latest HLSDK some observer stuff is performed serverside which ends up
+				// adding some extra viewheight when spectating in first person mode, so use
+				// cl_viewheight_mode 1 to avoid the extra viewheight
+
+				// Get eye position and angles
+				VectorCopy ( ent->origin, pparams->simorg );
+				VectorCopy ( ent->angles, pparams->cl_viewangles );
+
+				pparams->cl_viewangles[PITCH]*=-3.0f;	// see CL_ProcessEntityUpdate()
+
+				if ( ent->curstate.solid == SOLID_NOT )
+					pparams->cl_viewangles[ROLL] = 80;	// dead view angle
+			}
+			else
+			{
+				V_GetInEyePos( g_iUser2, pparams->simorg, pparams->cl_viewangles );
+			}
 
 			pparams->health = 1;
 


### PR DESCRIPTION
Fixes the height of the first person cam when spectating in games that use the latest HLSDK, like HL.
When playing HL with OpenAG you would have the cam 28 units higher than it should be in First Person spectator mode, which is a bit annoying.

`cl_viewheight_mode 0` - normal AG viewheight
`cl_viewheight_mode 1` - fixed viewheight for HL
