### PR TITLE
Multilayer overviews

### DIFF
--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -1280,8 +1280,7 @@ bool CHudSpectator::ParseOverviewFile( )
 	
 	char *pfile  = NULL;
 	
-	m_OverviewData = Overview();
-	m_OverviewData.map = gEngfuncs.pfnGetLevelName();
+	m_OverviewData = Overview(gEngfuncs.pfnGetLevelName());
 
 	const auto mapLen = m_OverviewData.map.size();
 	if ( mapLen == 0 )

--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -1305,7 +1305,7 @@ bool CHudSpectator::ParseOverviewFile( )
 
 	if (!pfile)
 	{
-		gEngfuncs.Con_DPrintf("Couldn't open file %s. Using default values for overiew mode.\n", filename );
+		gEngfuncs.Con_DPrintf("Couldn't open file %s. Using default values for overiew mode.\n", filename.c_str() );
 		return false;
 	}
 	
@@ -1323,7 +1323,7 @@ bool CHudSpectator::ParseOverviewFile( )
 			pfile = gEngfuncs.COM_ParseFile(pfile, token);
 			if ( stricmp( token, "{" ) ) 
 			{
-				gEngfuncs.Con_Printf("Error parsing overview file %s. (expected { )\n", filename );
+				gEngfuncs.Con_Printf("Error parsing overview file %s. (expected { )\n", filename.c_str() );
 				return false;
 			}
 
@@ -1364,7 +1364,7 @@ bool CHudSpectator::ParseOverviewFile( )
 				}
 				else
 				{
-					gEngfuncs.Con_Printf("Error parsing overview file %s. (%s unkown)\n", filename, token );
+					gEngfuncs.Con_Printf("Error parsing overview file %s. (%s unkown)\n", filename.c_str(), token );
 					return false;
 				}
 
@@ -1383,7 +1383,7 @@ bool CHudSpectator::ParseOverviewFile( )
 				
 			if ( stricmp( token, "{" ) ) 
 			{
-				gEngfuncs.Con_Printf("Error parsing overview file %s. (expected { )\n", filename );
+				gEngfuncs.Con_Printf("Error parsing overview file %s. (expected { )\n", filename.c_str() );
 				return false;
 			}
 
@@ -1406,7 +1406,7 @@ bool CHudSpectator::ParseOverviewFile( )
 				}
 				else
 				{
-					gEngfuncs.Con_Printf("Error parsing overview file %s. (%s unkown)\n", filename, token );
+					gEngfuncs.Con_Printf("Error parsing overview file %s. (%s unkown)\n", filename.c_str(), token );
 					return false;
 				}
 

--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -391,6 +391,24 @@ void CHudSpectator::SetSpectatorStartPosition()
 	iJumpSpectator = 1;	// jump anyway
 }
 
+void CHudSpectator::GetCameraView(Vector& pos, Vector& angle)
+{
+	if (m_pip->value == INSET_IN_EYE || g_iUser1 == OBS_IN_EYE)
+	{
+		V_GetInEyePos(g_iUser2, pos, angle);
+	}
+	else if (m_pip->value == INSET_CHASE_FREE || g_iUser1 == OBS_CHASE_FREE)
+	{
+		V_GetChasePos(g_iUser2, v_cl_angles, pos, angle);
+	}
+	else if (g_iUser1 == OBS_ROAMING)
+	{
+		VectorCopy(v_sim_org, pos);
+		VectorCopy(v_cl_angles, angle);
+	}
+	else
+		V_GetChasePos(g_iUser2, NULL, pos, angle);
+}
 
 void CHudSpectator::SetCameraView( vec3_t pos, vec3_t angle, float fov)
 {
@@ -1255,8 +1273,8 @@ bool CHudSpectator::IsActivePlayer(cl_entity_t * ent)
 
 bool CHudSpectator::ParseOverviewFile( )
 {
-	char filename[255];
-	char levelname[255];
+	std::string filename;
+	std::string levelname;
 	char token[1024];
 	float height;
 	
@@ -1273,19 +1291,17 @@ bool CHudSpectator::ParseOverviewFile( )
 	m_OverviewData.origin[1] = 0.0f;
 	m_OverviewData.origin[2] = 0.0f;
 	m_OverviewData.zoom	= 1.0f;
-	m_OverviewData.layers = 0;
-	m_OverviewData.layersHeights[0] = 0.0f;
-	strcpy( m_OverviewData.map, gEngfuncs.pfnGetLevelName() );
+	m_OverviewData.map = gEngfuncs.pfnGetLevelName();
 
-	if ( strlen( m_OverviewData.map ) == 0 )
+	const auto mapLen = m_OverviewData.map.size();
+	if ( mapLen == 0 )
 		return false; // not active yet
 
-	strcpy(levelname, m_OverviewData.map + 5);
-	levelname[strlen(levelname)-4] = 0;
-	
-	snprintf(filename, sizeof(filename), "overviews/%s.txt", levelname );
+	// Remove "maps/", ie. first 5 chars, and then the ".bsp" extension (4 chars)
+	levelname = m_OverviewData.map.substr(5, mapLen - 5 - 4);
+	filename = "overviews/" + levelname + ".txt";
 
-	pfile = (char *)gEngfuncs.COM_LoadFile( filename, 5, NULL);
+	pfile = (char *)gEngfuncs.COM_LoadFile(filename.c_str(), 5, NULL);
 
 	if (!pfile)
 	{
@@ -1360,11 +1376,7 @@ bool CHudSpectator::ParseOverviewFile( )
 		{
 			// parse a layer data
 
-			if ( m_OverviewData.layers == OVERVIEW_MAX_LAYERS )
-			{
-				gEngfuncs.Con_Printf("Error parsing overview file %s. ( too many layers )\n", filename );
-				return false;
-			}
+			OverviewLayer currLayer;
 
 			pfile = gEngfuncs.COM_ParseFile(pfile,token);
 
@@ -1382,15 +1394,15 @@ bool CHudSpectator::ParseOverviewFile( )
 				if ( !stricmp( token, "image" ) )
 				{
 					pfile = gEngfuncs.COM_ParseFile(pfile,token);
-					strcpy(m_OverviewData.layersImages[ m_OverviewData.layers ], token);
-					
+					currLayer.imagePath = token;
+
 					
 				} 
 				else if ( !stricmp( token, "height" ) )
 				{
 					pfile = gEngfuncs.COM_ParseFile(pfile,token); 
 					height = atof(token);
-					m_OverviewData.layersHeights[ m_OverviewData.layers ] = height;
+					currLayer.z = height;
 				}
 				else
 				{
@@ -1401,7 +1413,7 @@ bool CHudSpectator::ParseOverviewFile( )
 				pfile = gEngfuncs.COM_ParseFile(pfile,token); // parse next token
 			}
 
-			m_OverviewData.layers++;
+			m_OverviewData.layers.push_back(currLayer);
 
 		}
 	}
@@ -1417,13 +1429,13 @@ bool CHudSpectator::ParseOverviewFile( )
 
 void CHudSpectator::LoadMapSprites()
 {
-	// right now only support for one map layer
-	if (m_OverviewData.layers > 0 )
+	for (auto& layer : m_OverviewData.layers)
 	{
-		m_MapSprite = gEngfuncs.LoadMapSprite( m_OverviewData.layersImages[0] );
+		if (layer.imagePath.empty())
+			layer.mapSprite = (struct model_s*) gEngfuncs.GetSpritePointer(m_hsprUnkownMap);
+		else
+			layer.mapSprite = gEngfuncs.LoadMapSprite(layer.imagePath.c_str());
 	}
-	else
-		m_MapSprite = NULL; // the standard "unkown map" sprite will be used instead
 }
 
 void CHudSpectator::DrawOverviewLayer()
@@ -1431,13 +1443,16 @@ void CHudSpectator::DrawOverviewLayer()
 	float screenaspect, xs, ys, xStep, yStep, x,y,z;
 	int ix,iy,i,xTiles,yTiles,frame;
 
-	qboolean	hasMapImage = m_MapSprite?TRUE:FALSE;
-	model_t *   dummySprite = (struct model_s *)gEngfuncs.GetSpritePointer( m_hsprUnkownMap);
+	Vector camOrigin, camAngles;
+	GetCameraView(camOrigin, camAngles);
+
+	const auto currLayer = GetCurrentLayer(camOrigin);
+	const auto hasMapImage = currLayer.mapSprite == (struct model_s*)gEngfuncs.GetSpritePointer(m_hsprUnkownMap) ? false : true;
 
 	if ( hasMapImage)
 	{
-		i = m_MapSprite->numframes / (4*3);
-		i = sqrt((float)i);
+		i = currLayer.mapSprite->numframes / (4*3);
+		i = (int) sqrt((float)i);
 		xTiles = i*4;
 		yTiles = i*3;
 	}
@@ -1454,7 +1469,7 @@ void CHudSpectator::DrawOverviewLayer()
 	xs = m_OverviewData.origin[0];
 	ys = m_OverviewData.origin[1];
 	z  = ( 90.0f - v_angles[0] ) / 90.0f;		
-	z *= m_OverviewData.layersHeights[0]; // gOverviewData.z_min - 32;	
+	z *= m_OverviewData.origin.z;
 
 	// i = r_overviewTexture + ( layer*OVERVIEW_X_TILES*OVERVIEW_Y_TILES );
 
@@ -1479,10 +1494,7 @@ void CHudSpectator::DrawOverviewLayer()
 
 			for (ix = 0; ix < xTiles; ix++)
 			{
-				if (hasMapImage)
-					gEngfuncs.pTriAPI->SpriteTexture( m_MapSprite, frame );
-				else
-					gEngfuncs.pTriAPI->SpriteTexture( dummySprite, 0 );
+				gEngfuncs.pTriAPI->SpriteTexture( currLayer.mapSprite, frame );
 
 				gEngfuncs.pTriAPI->Begin( TRI_QUADS );
 					gEngfuncs.pTriAPI->TexCoord2f( 0, 0 );
@@ -1498,7 +1510,9 @@ void CHudSpectator::DrawOverviewLayer()
 					gEngfuncs.pTriAPI->Vertex3f (x, y+yStep, z);
 				gEngfuncs.pTriAPI->End();
 
-				frame++;
+				if (hasMapImage)
+					frame++;
+
 				x+= xStep;
 			}
 
@@ -1522,10 +1536,7 @@ void CHudSpectator::DrawOverviewLayer()
 						
 			for (iy = 0; iy < xTiles; iy++)	
 			{
-				if (hasMapImage)
-					gEngfuncs.pTriAPI->SpriteTexture( m_MapSprite, frame );
-				else
-					gEngfuncs.pTriAPI->SpriteTexture( dummySprite, 0 );
+				gEngfuncs.pTriAPI->SpriteTexture( currLayer.mapSprite, frame );
 
 				gEngfuncs.pTriAPI->Begin( TRI_QUADS );
 					gEngfuncs.pTriAPI->TexCoord2f( 0, 0 );
@@ -1541,7 +1552,8 @@ void CHudSpectator::DrawOverviewLayer()
 					gEngfuncs.pTriAPI->Vertex3f (x, y+yStep, z);
 				gEngfuncs.pTriAPI->End();
 
-				frame++;
+				if (hasMapImage)
+					frame++;
 				
 				y+=yStep;
 			}
@@ -1563,8 +1575,7 @@ void CHudSpectator::DrawOverviewEntities()
 	
 	float			zScale = (90.0f - v_angles[0] ) / 90.0f;
 	
-
-	z = m_OverviewData.layersHeights[0] * zScale;
+	z = m_OverviewData.origin.z * zScale;
 	// get yellow/brown HUD color
 	UnpackRGB(ir,ig,ib, gHUD.m_iDefaultHUDColor);
 	r = (float)ir/255.0f;
@@ -1692,22 +1703,7 @@ void CHudSpectator::DrawOverviewEntities()
 		return;
 
 	// get current camera position and angle
-
-	if ( m_pip->value == INSET_IN_EYE || g_iUser1 == OBS_IN_EYE )
-	{ 
-		V_GetInEyePos( g_iUser2, origin, angles );
-	}
-	else if ( m_pip->value == INSET_CHASE_FREE  || g_iUser1 == OBS_CHASE_FREE )
-	{
-		V_GetChasePos( g_iUser2, v_cl_angles, origin, angles );
-	}
-	else if ( g_iUser1 == OBS_ROAMING )
-	{
-		VectorCopy( v_sim_org, origin );
-		VectorCopy( v_cl_angles, angles );
-	}
-	else
-		V_GetChasePos( g_iUser2, NULL, origin, angles );
+	GetCameraView(origin, angles);
 
 	
 	// draw camera sprite
@@ -1943,10 +1939,15 @@ int CHudSpectator::ToggleInset(bool allowOff)
 void CHudSpectator::Reset()
 {
 	// Reset HUD
-	if ( strcmp( m_OverviewData.map, gEngfuncs.pfnGetLevelName() ) )
+	if ( strcmp( m_OverviewData.map.c_str(), gEngfuncs.pfnGetLevelName() ) )
 	{
 		// update level overview if level changed
 		ParseOverviewFile();
+
+		// A default layer for dummy overview when there's no overview file
+		if (m_OverviewData.layers.size() == 0)
+			m_OverviewData.layers.push_back(OverviewLayer());
+
 		LoadMapSprites();
 	}
 
@@ -1988,3 +1989,33 @@ void CHudSpectator::InitHUDData()
 	gHUD.m_iFOV =  CVAR_GET_FLOAT("default_fov");
 }
 
+CHudSpectator::OverviewLayer CHudSpectator::GetCurrentLayer(Vector playerPos)
+{
+	// Get the layer with highest Z, that will be the default layer,
+	// or it will be the dummy oneif an overview file doesn't exist for this map
+	OverviewLayer result = GetHighestLayer();
+
+	// Get the overview with highest Z that is below player Z position too
+	for (const auto& layer : m_OverviewData.layers)
+	{
+		if (playerPos.z < layer.z && layer.z < result.z)
+		{
+			result = layer;
+		}
+	}
+	return result;
+}
+CHudSpectator::OverviewLayer CHudSpectator::GetHighestLayer()
+{
+	// There's always at least one layer, because a dummy one is put if there is no overview file
+	OverviewLayer result = m_OverviewData.layers[0];
+
+	for (const auto& layer : m_OverviewData.layers)
+	{
+		if (layer.z > result.z)
+		{
+			result = layer;
+		}
+	}
+	return result;
+}

--- a/cl_dll/hud_spectator.h
+++ b/cl_dll/hud_spectator.h
@@ -57,6 +57,7 @@ class CHudSpectator : public CHudBase
 		std::string		imagePath;
 		float			z;
 		model_s*		mapSprite;
+
 		OverviewLayer()
 			: imagePath("")
 			, z(0.0f)
@@ -64,6 +65,7 @@ class CHudSpectator : public CHudBase
 		{
 		}
 	};
+
 	struct Overview
 	{
 		std::string					map;		// cl.levelname or empty
@@ -71,10 +73,22 @@ class CHudSpectator : public CHudBase
 		float						zoom;		// zoom of map images
 		std::vector<OverviewLayer>	layers;
 		qboolean					rotated;	// are map images rotated (90 degrees) ?
-		int			insetWindowX;
-		int			insetWindowY;
-		int			insetWindowHeight;
-		int			insetWindowWidth;
+		int							insetWindowX;
+		int							insetWindowY;
+		int							insetWindowHeight;
+		int							insetWindowWidth;
+
+		Overview()
+			: origin(Vector(0, 0, 0))
+			, zoom(1.0f)
+			, rotated(false)
+			, insetWindowX(4)
+			, insetWindowY(4)
+			, insetWindowHeight(180)
+			, insetWindowWidth(240)
+		{
+		}
+
 	};
 
 public:
@@ -150,7 +164,7 @@ private:
 	HSPRITE		m_hsprCamera;
 	HSPRITE		m_hsprPlayerDead;
 	HSPRITE		m_hsprViewcone;
-	HSPRITE		m_hsprUnkownMap;
+	HSPRITE		m_hsprUnknownMap;
 	HSPRITE		m_hsprBeam;
 	HSPRITE		m_hCrosshair;
 

--- a/cl_dll/hud_spectator.h
+++ b/cl_dll/hud_spectator.h
@@ -78,14 +78,19 @@ class CHudSpectator : public CHudBase
 		int							insetWindowHeight;
 		int							insetWindowWidth;
 
-		Overview()
-			: origin(Vector(0, 0, 0))
+		Overview(const std::string& map)
+			: map(map)
+			, origin(Vector(0, 0, 0))
 			, zoom(1.0f)
 			, rotated(false)
 			, insetWindowX(4)
 			, insetWindowY(4)
 			, insetWindowHeight(180)
 			, insetWindowWidth(240)
+		{
+		}
+
+		Overview() : Overview("")
 		{
 		}
 

--- a/cl_dll/hud_spectator.h
+++ b/cl_dll/hud_spectator.h
@@ -9,6 +9,9 @@
 #define SPECTATOR_H
 #pragma once
 
+#include <string>
+#include <vector>
+
 #include "cl_entity.h"
 #include "interpolation.h"
 
@@ -21,30 +24,12 @@
 
 #define MAX_SPEC_HUD_MESSAGES	8
 
-#define OVERVIEW_TILE_SIZE		128		// don't change this
-#define OVERVIEW_MAX_LAYERS		1
-
 extern void VectorAngles( const float *forward, float *angles );
 extern "C" void NormalizeAngles( float *angles );
 
 //-----------------------------------------------------------------------------
 // Purpose: Handles the drawing of the spectator stuff (camera & top-down map and all the things on it )
 //-----------------------------------------------------------------------------
-
-typedef struct overviewInfo_s {
-	char		map[64];	// cl.levelname or empty
-	vec3_t		origin;		// center of map
-	float		zoom;		// zoom of map images
-	int			layers;		// how may layers do we have
-	float		layersHeights[OVERVIEW_MAX_LAYERS];
-	char		layersImages[OVERVIEW_MAX_LAYERS][255];
-	qboolean	rotated;	// are map images rotated (90 degrees) ?
-	
-	int			insetWindowX;
-	int			insetWindowY;
-	int			insetWindowHeight;
-	int			insetWindowWidth;
-} overviewInfo_t;
 
 typedef struct overviewEntity_s {
 
@@ -67,6 +52,31 @@ typedef struct cameraWayPoint_s
 
 class CHudSpectator : public CHudBase
 {
+	struct OverviewLayer
+	{
+		std::string		imagePath;
+		float			z;
+		model_s*		mapSprite;
+		OverviewLayer()
+			: imagePath("")
+			, z(0.0f)
+			, mapSprite(nullptr)
+		{
+		}
+	};
+	struct Overview
+	{
+		std::string					map;		// cl.levelname or empty
+		Vector						origin;		// center of map
+		float						zoom;		// zoom of map images
+		std::vector<OverviewLayer>	layers;
+		qboolean					rotated;	// are map images rotated (90 degrees) ?
+		int			insetWindowX;
+		int			insetWindowY;
+		int			insetWindowHeight;
+		int			insetWindowWidth;
+	};
+
 public:
 	void Reset();
 	int  ToggleInset(bool allowOff);
@@ -100,13 +110,17 @@ public:
 	float	GetFOV();
 	bool	GetDirectorCamera(vec3_t &position, vec3_t &angle);
 	void	SetWayInterpolation(cameraWayPoint_t * prev, cameraWayPoint_t * start, cameraWayPoint_t * end, cameraWayPoint_t * next);
+	void	GetCameraView(Vector& pos, Vector& angle);
+
+	OverviewLayer GetCurrentLayer(Vector playerPos);
+	OverviewLayer GetHighestLayer();
 
 
 	int m_iDrawCycle;
 	client_textmessage_t m_HUDMessages[MAX_SPEC_HUD_MESSAGES];
 	char				m_HUDMessageText[MAX_SPEC_HUD_MESSAGES][128];
 	int					m_lastHudMessage;
-	overviewInfo_t		m_OverviewData;
+	Overview			m_OverviewData;
 	overviewEntity_t	m_OverviewEntities[MAX_OVERVIEW_ENTITIES];
 	int					m_iObserverFlags;
 	int					m_iSpectatorNumber;
@@ -142,7 +156,6 @@ private:
 
 	wrect_t		m_crosshairRect;
 
-	struct model_s * m_MapSprite;	// each layer image is saved in one sprite, where each tile is a sprite frame
 	float		m_flNextObserverInput;
 	float		m_FOV;
 	float		m_zoomDelta;


### PR DESCRIPTION
Valve added some support for multiple overview layers, but it seems that at the end they decided not to support them. So this is mostly refactoring of overview code and completing the support.

Some background on overviews:
- An overview is the top-down view of the map that you can see from spectator mode when pressing `+use`. You can rotate it by moving the mouse, and height (Z) is only taken into account for positioning player indicators or yourself, with a line going from the indicator to the overview image where you can see at which height players are depending on how long is the line. [Example overview image](https://imgur.com/a/3he7Ice).
- An overview is defined in a txt file located in the _overviews_ directory, with the same name as the corresponding map. [Example overview file (multilayered)](https://pastebin.com/LmQ33xnf).
- It has some properties like `zoom`, `origin`, `rotated`, and then you have the layers, that have a couple properties like `image` and `height`. They're more or less self-explanatory if you have seen overviews ingame. `height` is the minimum Z for a layer, and originally it was only used for positioning yourself higher or lower in the overview, but now it's also used to change the displayed overview image. So, for example, right when your origin (your cam's) goes below the current layer's `height`, it will switch to the next (lower) layer, if any.

This PR doesn't change the way these properties are used, so backwards compatibility is kept, ie. existing overviews will continue working the same way.

Here's a demonstration video of multilayered overviews. You can see how it switches the overview image based on your position (Z):
https://www.youtube.com/watch?v=3VJv8u2QOjo
