### PR TITLE
Client: Add cvar to hide corpses and fix standing corpses

### DIFF
--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -49,12 +49,14 @@ int CL_DLLEXPORT HUD_AddEntity( int type, struct cl_entity_s *ent, const char *m
 		break;
 	}
 
-	if (gHUD.m_pCvarFixStandingCorpses->value > 0 
-		&& (ent->player || ent->curstate.renderfx == kRenderFxDeadPlayer) && ent->curstate.framerate == 0)
-		ent->curstate.frame = 255;
-
+	// hide corpses option
 	if (gHUD.m_pCvarHideCorpses->value > 0 && ent->curstate.renderfx == kRenderFxDeadPlayer)
 		return 0;
+
+	// fix standing corpses from players with high fps by setting animation to his last frame
+	// note: we only do this when the animation is done (framerate is equal to 0)
+	if ((ent->player || ent->curstate.renderfx == kRenderFxDeadPlayer) && ent->curstate.framerate == 0)
+		ent->curstate.frame = 256.0f;
 			
 	// each frame every entity passes this function, so the overview hooks it to filter the overview entities
 	// in spectator mode:

--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -48,6 +48,14 @@ int CL_DLLEXPORT HUD_AddEntity( int type, struct cl_entity_s *ent, const char *m
 	default:
 		break;
 	}
+
+	if (gHUD.m_pCvarFixStandingCorpses->value > 0 
+		&& (ent->player || ent->curstate.renderfx == kRenderFxDeadPlayer) && ent->curstate.framerate == 0)
+		ent->curstate.frame = 255;
+
+	if (gHUD.m_pCvarHideCorpses->value > 0 && ent->curstate.renderfx == kRenderFxDeadPlayer)
+		return 0;
+			
 	// each frame every entity passes this function, so the overview hooks it to filter the overview entities
 	// in spectator mode:
 	// each frame every entity passes this function, so the overview hooks 

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -483,6 +483,8 @@ void CHud :: Init( void )
 	m_pCvarDrawDeathNoticesAlways = CVAR_CREATE( "cl_draw_deathnotices_always", "0", FCVAR_ARCHIVE );
 	m_pCvarAutostop = CVAR_CREATE("cl_autostop", "0", FCVAR_ARCHIVE);
 	m_pCvarViewheightMode = CVAR_CREATE("cl_viewheight_mode", "0", FCVAR_ARCHIVE);
+	m_pCvarHideCorpses = CVAR_CREATE("cl_hidecorpses", "0", FCVAR_ARCHIVE);
+	m_pCvarFixStandingCorpses = CVAR_CREATE("cl_fix_standing_corpses", "1", FCVAR_ARCHIVE);
 	m_pCvarColor = CVAR_CREATE( "hud_color", "", FCVAR_ARCHIVE );
 	cl_lw = gEngfuncs.pfnGetCvarPointer( "cl_lw" );
 

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -484,7 +484,6 @@ void CHud :: Init( void )
 	m_pCvarAutostop = CVAR_CREATE("cl_autostop", "0", FCVAR_ARCHIVE);
 	m_pCvarViewheightMode = CVAR_CREATE("cl_viewheight_mode", "0", FCVAR_ARCHIVE);
 	m_pCvarHideCorpses = CVAR_CREATE("cl_hidecorpses", "0", FCVAR_ARCHIVE);
-	m_pCvarFixStandingCorpses = CVAR_CREATE("cl_fix_standing_corpses", "1", FCVAR_ARCHIVE);
 	m_pCvarColor = CVAR_CREATE( "hud_color", "", FCVAR_ARCHIVE );
 	cl_lw = gEngfuncs.pfnGetCvarPointer( "cl_lw" );
 

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -588,6 +588,8 @@ public:
 	cvar_t	*m_pCvarDrawDeathNoticesAlways;
 	cvar_t	*m_pCvarAutostop;
 	cvar_t	*m_pCvarViewheightMode;
+	cvar_t	*m_pCvarHideCorpses;
+	cvar_t	*m_pCvarFixStandingCorpses;
 
 	int m_iFontHeight;
 

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -589,7 +589,6 @@ public:
 	cvar_t	*m_pCvarAutostop;
 	cvar_t	*m_pCvarViewheightMode;
 	cvar_t	*m_pCvarHideCorpses;
-	cvar_t	*m_pCvarFixStandingCorpses;
 
 	int m_iFontHeight;
 


### PR DESCRIPTION
Cvar `cl_fix_standing_corpses ` fixes the issue with standing corpses leaved by players playing with high FPS.

Cvar `cl_hidecorpses `gives you the ability to hide the corpses in case they bother you. If there wasn't a fix for the standing corpses, it becomes useful to counter that issue.