### PR TITLE
Make hud_speedometer draw even when hud_draw is 0

### DIFF
--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -196,6 +196,9 @@ int CHud :: Redraw( float flTime, int intermission )
 			if (m_Crosshairs.m_iFlags & HUD_ACTIVE)
 				m_Crosshairs.Draw(flTime);
 
+			if (m_Speedometer.m_iFlags & HUD_ACTIVE)
+				m_Speedometer.Draw(flTime);
+
 			if (gHUD.m_pCvarDrawDeathNoticesAlways->value != 0.0f
 				&& m_DeathNotice.m_iFlags & HUD_ACTIVE)
 				m_DeathNotice.Draw(flTime);


### PR DESCRIPTION
This is useful for creating HLKZ videos.