### PR TITLE
Fix linker relocation warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ include("CMake/helpers.cmake")
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # Set up some compiler-related things
 if(MSVC)


### PR DESCRIPTION
Building with GCC 10.2.0 and GNU ld 2.35 on Arch Linux causes a linker warning to appear:
```
[73/73] Linking CXX shared library client.so
/usr/bin/ld: external/discord-rpc/src/libdiscord-rpc.a(rpc_connection.cpp.o): warning: relocation against `_ZNK9rapidjson13GenericReaderINS_4UTF8IcEES2_20FixedLinearAllocatorILj2048EEE12NumberStreamINS_25GenericInsituStringStreamIS2_EELb0ELb0EE4PeekEv' in read-only section `.text._ZN9rapidjson13GenericReaderINS_4UTF8IcEES2_20FixedLinearAllocatorILj2048EEE7ConsumeINS5_12NumberStreamINS_25GenericInsituStringStreamIS2_EELb0ELb0EEEEEbRT_NSB_2ChE[_ZN9rapidjson13GenericReaderINS_4UTF8IcEES2_20FixedLinearAllocatorILj2048EEE7ConsumeINS5_12NumberStreamINS_25GenericInsituStringStreamIS2_EELb0ELb0EEEEEbRT_NSB_2ChE]'
/usr/bin/ld: warning: creating DT_TEXTREL in a shared object
```

Fix is to enable position-independent code (`-fPIC`) or in CMake `CMAKE_POSITION_INDEPENDENT_CODE`.