### PR TITLE
Add Unicode support to the scoreboard

### DIFF
--- a/cl_dll/CMakeLists.txt
+++ b/cl_dll/CMakeLists.txt
@@ -120,6 +120,8 @@ add_sources(
 	vgui_SpectatorPanel.h
 	vgui_TeamFortressViewport.cpp
 	vgui_teammenu.cpp
+	vgui_UnicodeTextImage.cpp
+	vgui_UnicodeTextImage.h
 	view.cpp
 	view.h
 	voice_status.cpp

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -484,6 +484,8 @@ void CHud :: Init( void )
 	m_pCvarAutostop = CVAR_CREATE("cl_autostop", "0", FCVAR_ARCHIVE);
 	m_pCvarViewheightMode = CVAR_CREATE("cl_viewheight_mode", "0", FCVAR_ARCHIVE);
 	m_pCvarHideCorpses = CVAR_CREATE("cl_hidecorpses", "0", FCVAR_ARCHIVE);
+	m_pCvarVGuiUnicode = CVAR_CREATE("vgui_unicode", "1", FCVAR_ARCHIVE);
+	m_pCvarVGuiUnicodeAA = CVAR_CREATE("vgui_unicode_aa", "1", FCVAR_ARCHIVE);
 	m_pCvarColor = CVAR_CREATE( "hud_color", "", FCVAR_ARCHIVE );
 	cl_lw = gEngfuncs.pfnGetCvarPointer( "cl_lw" );
 

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -589,6 +589,8 @@ public:
 	cvar_t	*m_pCvarAutostop;
 	cvar_t	*m_pCvarViewheightMode;
 	cvar_t	*m_pCvarHideCorpses;
+	cvar_t	*m_pCvarVGuiUnicode;
+	cvar_t	*m_pCvarVGuiUnicodeAA;
 
 	int m_iFontHeight;
 

--- a/cl_dll/vgui_ScorePanel.cpp
+++ b/cl_dll/vgui_ScorePanel.cpp
@@ -102,6 +102,10 @@ ScorePanel::ScorePanel(int x,int y,int wide,int tall) : Panel(x,y,wide,tall)
 	Font *tfont = pSchemes->getFont(hTitleScheme);
 	Font *smallfont = pSchemes->getFont(hSmallScheme);
 
+	m_UFont = UnicodeTextImage::createFont("Arial", YRES(12), 300, gHUD.m_pCvarVGuiUnicodeAA->value);
+	m_UTitleFont = UnicodeTextImage::createFont("Arial", tfont->getTall(), 700, gHUD.m_pCvarVGuiUnicodeAA->value);
+	m_USmallFont = UnicodeTextImage::createFont("Arial", smallfont->getTall(), 400, gHUD.m_pCvarVGuiUnicodeAA->value);
+
 	setBgColor(0, 0, 0, 96);
 	m_pCurrentHighlightLabel = NULL;
 	m_iHighlightRow = -1;
@@ -168,7 +172,7 @@ ScorePanel::ScorePanel(int x,int y,int wide,int tall) : Panel(x,y,wide,tall)
 
 		m_HeaderLabels[i].setBgColor(0,0,0,255);
 		m_HeaderLabels[i].setFgColor(Scheme::sc_primary1);
-		m_HeaderLabels[i].setFont(smallfont);
+		m_HeaderLabels[i].setFont(m_USmallFont, smallfont);
 		m_HeaderLabels[i].setContentAlignment(g_ColumnInfo[i].m_Alignment);
 
 		int yres = 12;
@@ -612,7 +616,7 @@ void ScorePanel::FillGrid()
 			pLabel->setVisible(true);
 			pLabel->setText2("");
 			pLabel->setImage(NULL);
-			pLabel->setFont(sfont);
+			pLabel->setFont(m_UFont, sfont);
 			pLabel->setTextOffset(0, 0);
 			
 			int rowheight = 13;
@@ -655,7 +659,7 @@ void ScorePanel::FillGrid()
 					rowheight = YRES(rowheight);
 				}
 				pLabel->setSize(pLabel->getWide(), rowheight);
-				pLabel->setFont(tfont);
+				pLabel->setFont(m_UTitleFont, tfont);
 
 				pGridRow->SetRowUnderline(	0,
 											true,
@@ -677,7 +681,7 @@ void ScorePanel::FillGrid()
 					rowheight = YRES(rowheight);
 				}
 				pLabel->setSize(pLabel->getWide(), rowheight);
-				pLabel->setFont(tfont);
+				pLabel->setFont(m_UTitleFont, tfont);
 
 				pGridRow->SetRowUnderline(0, true, YRES(3), 100, 100, 100, 0);
 
@@ -768,7 +772,7 @@ void ScorePanel::FillGrid()
 						}
 
 						pLabel->setText2(sz2);
-						pLabel->setFont2(smallfont);
+						pLabel->setFont2(m_USmallFont, smallfont);
 					}
 					break;
 				case COLUMN_VOICE:

--- a/cl_dll/vgui_UnicodeTextImage.cpp
+++ b/cl_dll/vgui_UnicodeTextImage.cpp
@@ -1,0 +1,552 @@
+#include <cwchar>
+#include <vector>
+
+#ifdef _WIN32
+
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <winsani_in.h>
+#include <Windows.h>
+#include <winsani_out.h>
+
+#else
+#include <dlfcn.h>
+#endif
+
+#include <VGUI_Font.h>
+#include "../public/interface.h"
+#include "vgui_UnicodeTextImage.h"
+#include "hud.h"
+#include "cl_util.h"
+
+namespace
+{
+
+typedef unsigned int VPANEL;
+typedef unsigned long HCursor;
+typedef unsigned long HTexture;
+
+class Color_VGUI2;
+class IHTMLResponses;
+class IHTMLChromeController;
+class IHTML;
+class IHTMLEvents;
+class VGuiVertex;
+
+class ISurface : public IBaseInterface
+{
+public:
+	// call to Shutdown surface; surface can no longer be used after this is called
+	virtual void Shutdown() = 0;
+
+	// frame
+	virtual void RunFrame() = 0;
+
+	// hierarchy root
+	virtual VPANEL GetEmbeddedPanel() = 0;
+	virtual void SetEmbeddedPanel(VPANEL pPanel) = 0;
+
+	// drawing context
+	virtual void PushMakeCurrent(VPANEL panel, bool useInsets) = 0;
+	virtual void PopMakeCurrent(VPANEL panel) = 0;
+
+	// rendering functions
+	virtual void DrawSetColor(int r, int g, int b, int a) = 0;
+	virtual void DrawSetColor(Color_VGUI2 col) = 0;
+
+	virtual void DrawFilledRect(int x0, int y0, int x1, int y1) = 0;
+	virtual void DrawOutlinedRect(int x0, int y0, int x1, int y1) = 0;
+
+	virtual void DrawLine(int x0, int y0, int x1, int y1) = 0;
+	virtual void DrawPolyLine(int *px, int *py, int numPoints) = 0;
+
+	virtual void DrawSetTextFont(UnicodeTextImage::HFont font) = 0;
+	virtual void DrawSetTextColor(int r, int g, int b, int a) = 0;
+	virtual void DrawSetTextColor(Color_VGUI2 col) = 0;
+	virtual void DrawSetTextPos(int x, int y) = 0;
+	virtual void DrawGetTextPos(int &x, int &y) = 0;
+	virtual void DrawPrintText(const wchar_t *text, int textLen) = 0;
+	virtual void DrawUnicodeChar(wchar_t wch) = 0;
+	virtual void DrawUnicodeCharAdd(wchar_t wch) = 0;
+
+	virtual void DrawFlushText() = 0;		// flushes any buffered text (for rendering optimizations)
+	virtual IHTML *CreateHTMLWindow(IHTMLEvents *events, VPANEL context) = 0;
+	virtual void PaintHTMLWindow(IHTML *htmlwin) = 0;
+	virtual void DeleteHTMLWindow(IHTML *htmlwin) = 0;
+
+	virtual void DrawSetTextureFile(int id, const char *filename, int hardwareFilter, bool forceReload) = 0;
+	virtual void DrawSetTextureRGBA(int id, const unsigned char *rgba, int wide, int tall, int hardwareFilter, bool forceReload) = 0;
+	virtual void DrawSetTexture(int id) = 0;
+	virtual void DrawGetTextureSize(int id, int &wide, int &tall) = 0;
+	virtual void DrawTexturedRect(int x0, int y0, int x1, int y1) = 0;
+	virtual bool IsTextureIDValid(int id) = 0;
+
+	virtual int CreateNewTextureID(bool procedural = false) = 0;
+
+	virtual void GetScreenSize(int &wide, int &tall) = 0;
+	virtual void SetAsTopMost(VPANEL panel, bool state) = 0;
+	virtual void BringToFront(VPANEL panel) = 0;
+	virtual void SetForegroundWindow(VPANEL panel) = 0;
+	virtual void SetPanelVisible(VPANEL panel, bool state) = 0;
+	virtual void SetMinimized(VPANEL panel, bool state) = 0;
+	virtual bool IsMinimized(VPANEL panel) = 0;
+	virtual void FlashWindow(VPANEL panel, bool state) = 0;
+	virtual void SetTitle(VPANEL panel, const wchar_t *title) = 0;
+	virtual void SetAsToolBar(VPANEL panel, bool state) = 0;		// removes the window's task bar entry (for context menu's, etc.)
+
+	// windows stuff
+	virtual void CreatePopup(VPANEL panel, bool minimised, bool showTaskbarIcon = true, bool disabled = false, bool mouseInput = true, bool kbInput = true) = 0;
+	virtual void SwapBuffers(VPANEL panel) = 0;
+	virtual void Invalidate(VPANEL panel) = 0;
+	virtual void SetCursor(HCursor cursor) = 0;
+	virtual bool IsCursorVisible() = 0;
+	virtual void ApplyChanges() = 0;
+	virtual bool IsWithin(int x, int y) = 0;
+	virtual bool HasFocus() = 0;
+
+	// returns true if the surface supports minimize & maximize capabilities
+	enum SurfaceFeature_e
+	{
+		ANTIALIASED_FONTS = 1,
+		DROPSHADOW_FONTS = 2,
+		ESCAPE_KEY = 3,
+		OPENING_NEW_HTML_WINDOWS = 4,
+		FRAME_MINIMIZE_MAXIMIZE = 5,
+		OUTLINE_FONTS = 6,
+		DIRECT_HWND_RENDER = 7,
+	};
+	virtual bool SupportsFeature(SurfaceFeature_e feature) = 0;
+
+	// restricts what gets drawn to one panel and it's children
+	// currently only works in the game
+	virtual void RestrictPaintToSinglePanel(VPANEL panel) = 0;
+
+	// these two functions obselete, use IInput::SetAppModalSurface() instead
+	virtual void SetModalPanel(VPANEL) = 0;
+	virtual VPANEL GetModalPanel() = 0;
+
+	virtual void UnlockCursor() = 0;
+	virtual void LockCursor() = 0;
+	virtual void SetTranslateExtendedKeys(bool state) = 0;
+	virtual VPANEL GetTopmostPopup() = 0;
+
+	// engine-only focus handling (replacing WM_FOCUS windows handling)
+	virtual void SetTopLevelFocus(VPANEL panel) = 0;
+
+	// fonts
+	// creates an empty handle to a vgui font.  windows fonts can be add to this via AddGlyphSetToFont().
+	virtual UnicodeTextImage::HFont CreateFont() = 0;
+
+	// adds to the font
+	enum EFontFlags
+	{
+		FONTFLAG_NONE,
+		FONTFLAG_ITALIC = 0x001,
+		FONTFLAG_UNDERLINE = 0x002,
+		FONTFLAG_STRIKEOUT = 0x004,
+		FONTFLAG_SYMBOL = 0x008,
+		FONTFLAG_ANTIALIAS = 0x010,
+		FONTFLAG_GAUSSIANBLUR = 0x020,
+		FONTFLAG_ROTARY = 0x040,
+		FONTFLAG_DROPSHADOW = 0x080,
+		FONTFLAG_ADDITIVE = 0x100,
+		FONTFLAG_OUTLINE = 0x200,
+		FONTFLAG_CUSTOM = 0x400,		// custom generated font - never fall back to asian compatibility mode
+		FONTFLAG_BITMAP = 0x800,		// compiled bitmap font - no fallbacks
+	};
+
+	virtual bool AddGlyphSetToFont(UnicodeTextImage::HFont font, const char *windowsFontName, int tall, int weight, int blur, int scanlines, int flags, int lowRange, int highRange) = 0;
+
+	// adds a custom font file (only supports true type font files (.ttf) for now)
+	virtual bool AddCustomFontFile(const char *fontFileName) = 0;
+
+	// returns the details about the font
+	virtual int GetFontTall(UnicodeTextImage::HFont font) = 0;
+	virtual void GetCharABCwide(UnicodeTextImage::HFont font, int ch, int &a, int &b, int &c) = 0;
+	virtual int GetCharacterWidth(UnicodeTextImage::HFont font, int ch) = 0;
+	virtual void GetTextSize(UnicodeTextImage::HFont font, const wchar_t *text, int &wide, int &tall) = 0;
+
+	// notify icons?!?
+	virtual VPANEL GetNotifyPanel() = 0;
+	virtual void SetNotifyIcon(VPANEL context, HTexture icon, VPANEL panelToReceiveMessages, const char *text) = 0;
+
+	// plays a sound
+	virtual void PlaySound(const char *fileName) = 0;
+
+	//!! these functions should not be accessed directly, but only through other vgui items
+	//!! need to move these to seperate interface
+	virtual int GetPopupCount() = 0;
+	virtual VPANEL GetPopup(int index) = 0;
+	virtual bool ShouldPaintChildPanel(VPANEL childPanel) = 0;
+	virtual bool RecreateContext(VPANEL panel) = 0;
+	virtual void AddPanel(VPANEL panel) = 0;
+	virtual void ReleasePanel(VPANEL panel) = 0;
+	virtual void MovePopupToFront(VPANEL panel) = 0;
+	virtual void MovePopupToBack(VPANEL panel) = 0;
+
+	virtual void SolveTraverse(VPANEL panel, bool forceApplySchemeSettings = false) = 0;
+	virtual void PaintTraverse(VPANEL panel) = 0;
+
+	virtual void EnableMouseCapture(VPANEL panel, bool state) = 0;
+
+	// returns the size of the workspace
+	virtual void GetWorkspaceBounds(int &x, int &y, int &wide, int &tall) = 0;
+
+	// gets the absolute coordinates of the screen (in windows space)
+	virtual void GetAbsoluteWindowBounds(int &x, int &y, int &wide, int &tall) = 0;
+
+	// gets the base resolution used in proportional mode
+	virtual void GetProportionalBase(int &width, int &height) = 0;
+
+	virtual void CalculateMouseVisible() = 0;
+	virtual bool NeedKBInput() = 0;
+
+	virtual bool HasCursorPosFunctions() = 0;
+	virtual void SurfaceGetCursorPos(int &x, int &y) = 0;
+	virtual void SurfaceSetCursorPos(int x, int y) = 0;
+
+
+	// SRC only functions!!!
+	virtual void DrawTexturedPolygon(VGuiVertex *pVertices, int n) = 0;
+	virtual int GetFontAscent(UnicodeTextImage::HFont font, wchar_t wch) = 0;
+
+	// web browser
+	virtual void SetAllowHTMLJavaScript(bool state) = 0;
+
+	virtual void SetLanguage(const char *pchLang) = 0;
+
+	virtual const char *GetLanguage() = 0;
+
+	virtual bool DeleteTextureByID(int id) = 0;
+
+	virtual void DrawUpdateRegionTextureBGRA(int nTextureID, int x, int y, const unsigned char *pchData, int wide, int tall) = 0;
+
+	virtual void DrawSetTextureBGRA(int id, const unsigned char *pchData, int wide, int tall) = 0;
+
+	virtual void CreateBrowser(VPANEL panel, IHTMLResponses *pBrowser, bool bPopupWindow, const char *pchUserAgentIdentifier) = 0;
+
+	virtual void RemoveBrowser(VPANEL panel, IHTMLResponses *pBrowser) = 0;
+
+	virtual IHTMLChromeController *AccessChromeHTMLController() = 0;
+};
+
+#define VGUI_SURFACE_INTERFACE_VERSION "VGUI_Surface026"
+
+class ILocalize : public IBaseInterface
+{
+public:
+	virtual void Something1() = 0;
+	virtual void Something2() = 0;
+	virtual void Something3() = 0;
+
+	// Converts UTF-8 to WString
+	virtual int ConvertANSIToUnicode(const char *ansi, wchar_t *unicode, int unicodeBufferSizeInBytes) = 0;
+};
+
+#define VGUI_LOCALIZE_INTERFACE_VERSION "VGUI_Localize003"
+
+bool g_bSurfaceLoaded = false;
+
+// hw.dll or sw.dll on Windows, hw.so on Linux, hw.dylib on macOS.
+CSysModule *g_hEngineModule = nullptr;
+CSysModule *g_hVGuiModule = nullptr;
+
+ISurface *g_pVGuiSurface = nullptr;
+ILocalize *g_pVGuiLocalize = nullptr;
+
+}
+
+void UnicodeTextImage::initInterfaces()
+{
+	static bool bTriedToLoad = false;
+	if (bTriedToLoad)
+		return;
+
+	// Surface needs to be loaded only once, even if it fails.
+	bTriedToLoad = true;
+
+#ifdef _WIN32
+
+	HMODULE hw, sw, vgui2;
+
+	// Try hardware engine (hw.dll)
+	GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, "hw.dll", &hw);
+	if (hw)
+	{
+		g_hEngineModule = reinterpret_cast<CSysModule *>(hw);
+	}
+	else
+	{
+		// Try software engine (sw.dll)
+		GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, "hw.dll", &sw);
+		if (sw)
+		{
+			g_hEngineModule = reinterpret_cast<CSysModule *>(sw);
+		}
+	}
+
+	// Load vgui2.dll
+	GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, "vgui2.dll", &vgui2);
+	g_hVGuiModule = reinterpret_cast<CSysModule *>(vgui2);
+
+#else
+	
+#if defined(OSX)
+#define DLL_EXT ".dylib"
+#elif defined(LINUX)
+#define DLL_EXT ".so"
+#endif
+
+	// hw.so is guranteed to be loaded as it's the only engine library on Linux/macOS.
+	g_hEngineModule = reinterpret_cast<CSysModule *>(dlopen("./hw" DLL_EXT, RTLD_NOW | RTLD_NOLOAD));
+	g_hVGuiModule = reinterpret_cast<CSysModule *>(dlopen("./vgui2" DLL_EXT, RTLD_NOW | RTLD_NOLOAD));
+
+#endif
+
+	if (!g_hEngineModule)
+	{
+		ConsolePrint("UnicodeTextImage: Error: Engine module handle is null.\n");
+		return;
+	}
+
+	if (!g_hVGuiModule)
+	{
+		ConsolePrint("UnicodeTextImage: Error: VGUI2 library handle is null.\n");
+		return;
+	}
+
+	auto fnLoadInterface = [](const char *moduleName, CSysModule *pModule, const char *ifaceName, auto &pIface)
+	{
+		using IfaceType = std::remove_reference<decltype(pIface)>::type;
+
+		CreateInterfaceFn fnFactory = Sys_GetFactory(pModule);
+		if (!fnFactory)
+		{
+			gEngfuncs.Con_Printf("UnicodeTextImage: Error: %s doesn't export factory.\n", moduleName);
+			return;
+		}
+
+		pIface = static_cast<IfaceType>(fnFactory(ifaceName, nullptr));
+		if (!g_pVGuiSurface)
+		{
+			gEngfuncs.Con_Printf("UnicodeTextImage: Error: %s doesn't export %s.\n", moduleName, ifaceName);
+			return;
+		}
+	};
+
+	fnLoadInterface("Engine", g_hEngineModule, VGUI_SURFACE_INTERFACE_VERSION, g_pVGuiSurface);
+	fnLoadInterface("VGUI2", g_hVGuiModule, VGUI_LOCALIZE_INTERFACE_VERSION, g_pVGuiLocalize);
+
+	g_bSurfaceLoaded = true;
+}
+
+bool UnicodeTextImage::shouldFallback()
+{
+	return !g_bSurfaceLoaded || !gHUD.m_pCvarVGuiUnicode->value;
+}
+
+UnicodeTextImage::HFont UnicodeTextImage::createFont(const char *fontName, int tall, int weight, bool antialias)
+{
+	initInterfaces();
+
+	if (!g_bSurfaceLoaded)
+		return INVALID_FONT;
+
+	int flags = 0;
+	if (antialias && (tall >= MIN_AA_FONT_SIZE || gHUD.m_pCvarVGuiUnicodeAA->value == 2))
+		flags |= ISurface::FONTFLAG_ANTIALIAS;
+
+	HFont font = g_pVGuiSurface->CreateFont();
+	g_pVGuiSurface->AddGlyphSetToFont(font, fontName, tall, weight, 0, 0, flags, 0, 0);
+	return font;
+}
+
+UnicodeTextImage::UnicodeTextImage() : BaseClass("")
+{
+	initInterfaces();
+}
+
+void UnicodeTextImage::getTextSize(int &wide, int &tall)
+{
+	if (shouldFallback())
+	{
+		BaseClass::getTextSize(wide, tall);
+		return;
+	}
+
+	wide = 0;
+	tall = g_pVGuiSurface->GetFontTall(m_Font);
+
+	for (wchar_t ch : m_Text)
+	{
+		// Ignore linebreaks
+		if (ch == L'\r' || ch == L'\n')
+			continue;
+
+		wide += g_pVGuiSurface->GetCharacterWidth(m_Font, ch);
+	}
+}
+
+void UnicodeTextImage::getTextSizeWrapped(int &wide, int &tall)
+{
+	assert(!("UnicodeTextImage::getTextSizeWrapped is not supported"));
+}
+
+UnicodeTextImage::HFont UnicodeTextImage::getUnicodeFont()
+{
+	return m_Font;
+}
+
+void UnicodeTextImage::setText(int textBufferLen, const char *text)
+{
+	if (shouldFallback())
+	{
+		BaseClass::setText(textBufferLen, text);
+		return;
+	}
+
+	if (!text || !text[0])
+	{
+		m_Text.clear();
+	}
+	else
+	{
+		std::vector<wchar_t> wbuf(textBufferLen + 1);
+		g_pVGuiLocalize->ConvertANSIToUnicode(text, wbuf.data(), wbuf.size() * sizeof(wchar_t));
+		m_Text = wbuf.data();
+	}
+
+	// Update image size
+	int wide, tall;
+	getTextSize(wide, tall);
+	setSize(wide, tall);
+}
+
+void UnicodeTextImage::setText(const char *text)
+{
+	if (shouldFallback())
+	{
+		BaseClass::setText(text);
+		return;
+	}
+
+	if (!text || !text[0])
+	{
+		setText(1, "");
+		return;
+	}
+
+	setText(strlen(text) + 1, text);
+}
+
+void UnicodeTextImage::setFont(HFont font, vgui::Font *fallbackFont)
+{
+	m_Font = font;
+	BaseClass::setFont(fallbackFont);
+}
+
+void UnicodeTextImage::setFont(vgui::Scheme::SchemeFont schemeFont)
+{
+	assert(!("UnicodeTextImage::setFont(SchemeFont) is not supported"));
+}
+
+void UnicodeTextImage::setFont(vgui::Font *font)
+{
+	assert(!("UnicodeTextImage::setFont(Font *) is not supported"));
+}
+
+void UnicodeTextImage::setPos(int x, int y)
+{
+	BaseClass::setPos(x, y);
+}
+
+void UnicodeTextImage::paint(vgui::Panel *panel)
+{
+	if (shouldFallback())
+	{
+		BaseClass::paint(panel);
+
+		// Draw image bounds (good for debugging)
+#if 0
+		{
+			int x0, y0;
+			getPos(x0, y0);
+
+			vgui::Color color;
+			int r, g, b, a;
+			getColor(color);
+			color.getColor(r, g, b, a);
+
+			int wide, tall;
+			BaseClass::getTextSize(wide, tall);
+
+			g_pVGuiSurface->DrawSetColor(r, g, b, 255);
+			g_pVGuiSurface->DrawOutlinedRect(x0, y0, x0 + wide, y0 + tall);
+		}
+#endif
+
+		return;
+	}
+
+	// Can't have no font and a string to draw
+	assert(m_Font != INVALID_FONT || m_Text.empty());
+
+	if (m_Font == INVALID_FONT)
+	{
+		return;
+	}
+
+	// HACK: Drawing text after images may use incorrect texture.
+	//
+	// Explanation (pseudocode):
+	// vgui1_drawSetTexture(id) {
+	//   updateOpenGLTexture(id);
+	// }
+	//
+	// vgui2_DrawSetTexture(id) {	// This one used by VGUI2 fonts
+	//   if (internalTextureId == id) {
+	//     return;
+	//   }
+	//   internalTextureId = id;
+	//   vgui1_drawSetTexture(id);
+	// }
+	//
+	// Updating VGUI1 texture causes VGUI2 to think that texture hasn't changed.
+
+	// Call DrawSetTexture twice to make sure that it's updated to 0.
+	g_pVGuiSurface->DrawSetTexture(1);
+	g_pVGuiSurface->DrawSetTexture(0);
+
+	vgui::Color color;
+	int r, g, b, a;
+	getColor(color);
+	color.getColor(r, g, b, a);
+	g_pVGuiSurface->DrawSetTextColor(r, g, b, 255);
+	g_pVGuiSurface->DrawSetTextFont(m_Font);
+
+	int x, y;
+	getPos(x, y);
+
+	for (int i = 0; i < m_Text.size(); i++)
+	{
+		wchar_t ch = m_Text[i];
+
+		// Ignore linebreaks
+		if (ch == L'\r' || ch == L'\n')
+			continue;
+
+		g_pVGuiSurface->DrawSetTextPos(x, y);
+		g_pVGuiSurface->DrawUnicodeChar(ch);
+		x += g_pVGuiSurface->GetCharacterWidth(m_Font, ch);
+	}
+
+	// Draw image bounds (good for debugging)
+#if 0
+	{
+		int x0, y0;
+		getPos(x0, y0);
+		g_pVGuiSurface->DrawSetColor(r, g, b, 255);
+		g_pVGuiSurface->DrawOutlinedRect(x0, y0, x, y0 + g_pVGuiSurface->GetFontTall(m_Font));
+	}
+#endif
+}

--- a/cl_dll/vgui_UnicodeTextImage.cpp
+++ b/cl_dll/vgui_UnicodeTextImage.cpp
@@ -1,5 +1,6 @@
 #include <cwchar>
 #include <vector>
+#include <type_traits>
 
 #ifdef _WIN32
 
@@ -317,7 +318,7 @@ void UnicodeTextImage::initInterfaces()
 
 	auto fnLoadInterface = [](const char *moduleName, CSysModule *pModule, const char *ifaceName, auto &pIface)
 	{
-		using IfaceType = std::remove_reference<decltype(pIface)>::type;
+		using IfaceType = typename std::remove_reference<decltype(pIface)>::type;
 
 		CreateInterfaceFn fnFactory = Sys_GetFactory(pModule);
 		if (!fnFactory)

--- a/cl_dll/vgui_UnicodeTextImage.h
+++ b/cl_dll/vgui_UnicodeTextImage.h
@@ -1,0 +1,114 @@
+#ifndef VGUI_UNICODE_TEXT_IMAGE_H
+#define VGUI_UNICODE_TEXT_IMAGE_H
+#include <string>
+#include <VGUI_TextImage.h>
+
+/**
+ * A VGUI1 text image that supports Unicode by rendering chars via VGUI2.
+ * It can only draw text in one line.
+ * If VGUI2 is not available, it falls back to VGUI1 TextImage behavior.
+ */
+class UnicodeTextImage : public vgui::TextImage
+{
+public:
+	using BaseClass = vgui::TextImage;
+
+	/**
+	 * Type for VGUI2 font handle.
+	 */
+	using HFont = unsigned int;
+
+	/**
+	 * An invalid VGUI2 font handle.
+	 */
+	static constexpr HFont INVALID_FONT = 0;
+
+	/**
+	 * Minimum size of font to enable antialiasing in display pixels.
+	 * Samll fonts with antialiasing look blurry.
+	 */
+	static constexpr int MIN_AA_FONT_SIZE = 21;
+
+	/**
+	 * Loads interfaces from the engine.
+	 */
+	static void initInterfaces();
+
+	/**
+	 * Returns true if UnicodeTextImage falls back to vgui::TextImage.
+	 * If true, it will behave exactly like TextImage, without unicode support.
+	 */
+	static bool shouldFallback();
+
+	/**
+	 * Creates a font.
+	 * @param	fontName	Name of the font in the OS
+	 * @param	tall		Height of the font in pixels
+	 * @param	weight		Weight of the font
+	 * @param	antialias	Enable antialiasing (if tall >= MIN_AA_FONT_SIZE or vgui_unicode_aa = 2)
+	 */
+	static HFont createFont(const char *fontName, int tall, int weight, bool antialias);
+
+	//------------------------------------------------------------------
+
+	/**
+	 * Contstructs an empty TextImage.
+	 */
+	UnicodeTextImage();
+
+	/**
+	 * Returns size of the text.
+	 */
+	virtual void getTextSize(int &wide, int &tall) override;
+
+	/**
+	 * Unsupported.
+	 */
+	virtual void getTextSizeWrapped(int &wide, int &tall) override;
+
+	/**
+	 * Returns VGUI2 font handle.
+	 */
+	virtual HFont getUnicodeFont();
+
+	/**
+	 * Sets image text.
+	 * @param	textBufferLen	Size of text buffer. Must be at least strlen(text) + 1
+	 * @param	text			UTF-8 encoded text
+	 */
+	virtual void setText(int textBufferLen, const char *text) override;
+
+	/**
+	 * Sets image text.
+	 * @param	text	UTF-8 encoded text
+	 */
+	virtual void setText(const char *text) override;
+	
+	/**
+	 * Sets the font of the text.
+	 * @param	font			Unicode VGUI2 font
+	 * @param	fallbackFont	VGUI1 font if Unicode is disabled/not available
+	 */
+	virtual void setFont(HFont font, vgui::Font *fallbackFont);
+
+	/**
+	 * Unsupported.
+	 */
+	virtual void setFont(vgui::Scheme::SchemeFont schemeFont) override;
+
+	/**
+	 * Unsupported.
+	 */
+	virtual void setFont(vgui::Font *font) override;
+
+	virtual void setPos(int x, int y) override;
+
+protected:
+	virtual void paint(vgui::Panel *panel) override;
+
+private:
+	HFont m_Font = INVALID_FONT;
+	std::wstring m_Text;
+};
+
+#endif


### PR DESCRIPTION
This pull request adds support of Unicode to the scoreboard.

`UnicodeTextImage` class was added that replaces `vgui::TextImage` in the scoreboard. It uses VGUI2 ISurface interface (exposed by the engine) to draw Unicode chars and load fonts. If VGUI2 is not available (e.g. an engine update broke interface compatibility or game is running on Xash3D), it will fall back to `vgui::TextImage`. VGUI2 fonts also support anti-aliasing and it's enabled for large fonts (small fonts look blurry with AA).

To draw Unicode chars, UTF-8 text needs to be converted to a wide string (UTF-16 on Windows, UTF-32 on Linux and macOS). It is done using `ILocalize::ConvertANSIToUnicode` (exported by vgui2.dll). I couldn't use `std::mbstowcs` because it doesn't work on Windows.

A few cvars were added that control behavior of UnicodeTextImage.
- `vgui_unicode` - enables/disables unicode support and font rendering via VGUI2. If changed after the map was loaded, requires game restart.
- `vgui_unicode_aa` - enables/disables anti-aliasing of fonts. If changed after the map was loaded, requires game restart. Value of 2 enables AA for all fonts (even small ones).

Comparison of behavior (best viewed in full resolution)
![openag_unicode](https://user-images.githubusercontent.com/20199236/94989823-b33e2500-05a1-11eb-8c2a-f11965c249f7.png)

A few screenshots (best viewed in full resolution):

![ncp_rockbhop_ez0000](https://user-images.githubusercontent.com/20199236/94989906-365f7b00-05a2-11eb-84b3-5725ed63ace0.png)

![crossfire0000](https://user-images.githubusercontent.com/20199236/94989911-46775a80-05a2-11eb-9c42-e3ceebbc879f.png)

I tested font rendering on resolutions 640x480, 800x600, 1024x768, 1600x900 and 1920x1080 and didn't find any problems.

The pull request was tested on Linux and I don't see any reason it wouldn't work on macOS (if it's supported).