### PR TITLE
Implement ducktap autofunc

### DIFF
--- a/cl_dll/input.cpp
+++ b/cl_dll/input.cpp
@@ -66,7 +66,7 @@ cvar_t	*cl_yawspeed;
 cvar_t	*cl_pitchspeed;
 cvar_t	*cl_anglespeedkey;
 cvar_t	*cl_vsmoothing;
-cvar_t	*cl_ducktap_priority;
+cvar_t	*cl_autojump_priority;
 
 namespace autofuncs
 {
@@ -798,14 +798,14 @@ void CL_DLLEXPORT CL_CreateMove ( float frametime, struct usercmd_s *cmd, int ac
 	//
 	cmd->buttons = CL_ButtonBits( 1 );
 
-	if (cl_ducktap_priority->value != 0.0f)
+	if (cl_autojump_priority->value != 0.0f)
 		autofuncs::handle_autojump(cmd);
 
 	if (in_ducktap.state & 1)
 	{
 		cmd->buttons |= IN_DUCK;
 		autofuncs::handle_ducktap(cmd);
-	} else if (cl_ducktap_priority->value == 0.0f)
+	} else if (cl_autojump_priority->value == 0.0f)
 		autofuncs::handle_autojump(cmd);
 	
 
@@ -1075,7 +1075,7 @@ void InitInput (void)
 	cl_vsmoothing		= gEngfuncs.pfnRegisterVariable ( "cl_vsmoothing", "0.05", FCVAR_ARCHIVE );
 
 	autofuncs::cl_autojump = gEngfuncs.pfnRegisterVariable ( "cl_autojump", "1", FCVAR_ARCHIVE );
-	cl_ducktap_priority = gEngfuncs.pfnRegisterVariable ( "cl_ducktap_priority", "0", FCVAR_ARCHIVE ); 
+	cl_autojump_priority = gEngfuncs.pfnRegisterVariable ( "cl_autojump_priority", "0", FCVAR_ARCHIVE ); 
 
 	m_pitch			    = gEngfuncs.pfnRegisterVariable ( "m_pitch","0.022", FCVAR_ARCHIVE );
 	m_yaw				= gEngfuncs.pfnRegisterVariable ( "m_yaw","0.022", FCVAR_ARCHIVE );

--- a/cl_dll/input.cpp
+++ b/cl_dll/input.cpp
@@ -799,7 +799,7 @@ void CL_DLLEXPORT CL_CreateMove ( float frametime, struct usercmd_s *cmd, int ac
 	if (in_ducktap.state & 1)
 	{
 		cmd->buttons |= IN_DUCK;
-		autofuncs::handle_ducktap(cmd);
+		autofuncs::handle_ducktap(cmd); // Ducktap takes priority over autojump
 	} else 
 		autofuncs::handle_autojump(cmd);
 

--- a/cl_dll/input.cpp
+++ b/cl_dll/input.cpp
@@ -66,6 +66,7 @@ cvar_t	*cl_yawspeed;
 cvar_t	*cl_pitchspeed;
 cvar_t	*cl_anglespeedkey;
 cvar_t	*cl_vsmoothing;
+cvar_t	*cl_ducktap_priority;
 
 namespace autofuncs
 {
@@ -797,11 +798,14 @@ void CL_DLLEXPORT CL_CreateMove ( float frametime, struct usercmd_s *cmd, int ac
 	//
 	cmd->buttons = CL_ButtonBits( 1 );
 
+	if (cl_ducktap_priority->value != 0.0f)
+		autofuncs::handle_autojump(cmd);
+
 	if (in_ducktap.state & 1)
 	{
 		cmd->buttons |= IN_DUCK;
 		autofuncs::handle_ducktap(cmd);
-	} else 
+	} else if (cl_ducktap_priority->value == 0.0f)
 		autofuncs::handle_autojump(cmd);
 	
 
@@ -1071,6 +1075,7 @@ void InitInput (void)
 	cl_vsmoothing		= gEngfuncs.pfnRegisterVariable ( "cl_vsmoothing", "0.05", FCVAR_ARCHIVE );
 
 	autofuncs::cl_autojump = gEngfuncs.pfnRegisterVariable ( "cl_autojump", "1", FCVAR_ARCHIVE );
+	cl_ducktap_priority = gEngfuncs.pfnRegisterVariable ( "cl_ducktap_priority", "0", FCVAR_ARCHIVE ); 
 
 	m_pitch			    = gEngfuncs.pfnRegisterVariable ( "m_pitch","0.022", FCVAR_ARCHIVE );
 	m_yaw				= gEngfuncs.pfnRegisterVariable ( "m_yaw","0.022", FCVAR_ARCHIVE );

--- a/cl_dll/input.cpp
+++ b/cl_dll/input.cpp
@@ -100,6 +100,22 @@ namespace autofuncs
 
 		s_jump_was_down_last_frame = ((cmd->buttons & IN_JUMP) != 0);
 	}
+
+	static void handle_ducktap(usercmd_t* cmd)
+	{
+
+		static bool s_duck_was_down_last_frame = false;
+
+		bool should_release_duck = (!player.onground && !player.inwater && player.walking);
+
+		if (s_duck_was_down_last_frame && player.onground && !player.inwater && player.walking)
+				should_release_duck = true;
+
+		if (should_release_duck)
+				cmd->buttons &= ~IN_DUCK;
+
+		s_duck_was_down_last_frame = ((cmd->buttons & IN_DUCK) != 0);
+	}
 }
 
 extern "C" void update_player_info(int onground, int inwater, int walking)
@@ -156,6 +172,7 @@ kbutton_t	in_alt1;
 kbutton_t	in_score;
 kbutton_t	in_break;
 kbutton_t	in_graph;  // Display the netgraph
+kbutton_t	in_ducktap;
 
 typedef struct kblist_s
 {
@@ -435,6 +452,8 @@ void IN_LeftDown(void) {KeyDown(&in_left);}
 void IN_LeftUp(void) {KeyUp(&in_left);}
 void IN_RightDown(void) {KeyDown(&in_right);}
 void IN_RightUp(void) {KeyUp(&in_right);}
+void IN_DucktapUp(void) {KeyUp(&in_ducktap);}
+void IN_DucktapDown(void) {KeyDown(&in_ducktap);}
 
 void IN_ForwardDown(void)
 {
@@ -778,7 +797,14 @@ void CL_DLLEXPORT CL_CreateMove ( float frametime, struct usercmd_s *cmd, int ac
 	//
 	cmd->buttons = CL_ButtonBits( 1 );
 
-	autofuncs::handle_autojump(cmd);
+	if (in_ducktap.state & 1)
+	{
+		cmd->buttons |= IN_DUCK;
+		autofuncs::handle_ducktap(cmd);
+	} else 
+		autofuncs::handle_autojump(cmd);
+	
+
 
 	// If they're in a modal dialog, ignore the attack button.
 	if(GetClientVoiceMgr()->IsInSquelchMode())
@@ -934,6 +960,7 @@ int CL_ButtonBits( int bResetState )
 		in_reload.state &= ~2;
 		in_alt1.state &= ~2;
 		in_score.state &= ~2;
+		in_ducktap.state &= ~2;
 	}
 
 	return bits;
@@ -1025,6 +1052,8 @@ void InitInput (void)
 	gEngfuncs.pfnAddCommand ("-graph", IN_GraphUp);
 	gEngfuncs.pfnAddCommand ("+break",IN_BreakDown);
 	gEngfuncs.pfnAddCommand ("-break",IN_BreakUp);
+	gEngfuncs.pfnAddCommand ("+ducktap", IN_DucktapDown);
+	gEngfuncs.pfnAddCommand ("-ducktap", IN_DucktapUp);
 
 	lookstrafe			= gEngfuncs.pfnRegisterVariable ( "lookstrafe", "0", FCVAR_ARCHIVE );
 	lookspring			= gEngfuncs.pfnRegisterVariable ( "lookspring", "0", FCVAR_ARCHIVE );

--- a/cl_dll/input.cpp
+++ b/cl_dll/input.cpp
@@ -66,7 +66,6 @@ cvar_t	*cl_yawspeed;
 cvar_t	*cl_pitchspeed;
 cvar_t	*cl_anglespeedkey;
 cvar_t	*cl_vsmoothing;
-cvar_t	*cl_autojump_priority;
 
 namespace autofuncs
 {
@@ -104,7 +103,6 @@ namespace autofuncs
 
 	static void handle_ducktap(usercmd_t* cmd)
 	{
-
 		static bool s_duck_was_down_last_frame = false;
 
 		bool should_release_duck = (!player.onground && !player.inwater && player.walking);
@@ -798,17 +796,12 @@ void CL_DLLEXPORT CL_CreateMove ( float frametime, struct usercmd_s *cmd, int ac
 	//
 	cmd->buttons = CL_ButtonBits( 1 );
 
-	if (cl_autojump_priority->value != 0.0f)
-		autofuncs::handle_autojump(cmd);
-
 	if (in_ducktap.state & 1)
 	{
 		cmd->buttons |= IN_DUCK;
 		autofuncs::handle_ducktap(cmd);
-	} else if (cl_autojump_priority->value == 0.0f)
+	} else 
 		autofuncs::handle_autojump(cmd);
-	
-
 
 	// If they're in a modal dialog, ignore the attack button.
 	if(GetClientVoiceMgr()->IsInSquelchMode())
@@ -1075,7 +1068,6 @@ void InitInput (void)
 	cl_vsmoothing		= gEngfuncs.pfnRegisterVariable ( "cl_vsmoothing", "0.05", FCVAR_ARCHIVE );
 
 	autofuncs::cl_autojump = gEngfuncs.pfnRegisterVariable ( "cl_autojump", "1", FCVAR_ARCHIVE );
-	cl_autojump_priority = gEngfuncs.pfnRegisterVariable ( "cl_autojump_priority", "0", FCVAR_ARCHIVE ); 
 
 	m_pitch			    = gEngfuncs.pfnRegisterVariable ( "m_pitch","0.022", FCVAR_ARCHIVE );
 	m_yaw				= gEngfuncs.pfnRegisterVariable ( "m_yaw","0.022", FCVAR_ARCHIVE );


### PR DESCRIPTION
Adds a command, `+ducktap` which works as an automatic perfect duckroll. 
Also adds a cvar `cl_autojump_priority`, which controls whether ducktap or jump take precedence.