### PR TITLE
Fix OOB in spectator overview rendering

### DIFF
--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -1432,6 +1432,11 @@ void CHudSpectator::DrawOverviewLayer()
 	float screenaspect, xs, ys, xStep, yStep, x,y,z;
 	int ix,iy,i,xTiles,yTiles,frame;
 
+	// m_OverviewData.layers must have at least one dummy overview, which is added in Reset().
+	// But it's possible for rendering to begin before ResetHUD message is received.
+	if (m_OverviewData.layers.empty())
+		return;
+
 	Vector camOrigin, camAngles;
 	GetCameraView(camOrigin, camAngles);
 


### PR DESCRIPTION
Spectator overview rendering code expects to have at least one layer (which is added in `CHudSpectator::Reset()`) but rendering can begin before `ResetHUD` message is received by the client and layers are added.

The PR adds a check to `CHudSpectator::DrawOverviewLayer` that skips rendering overview until layers are added.