### PR TITLE
Add unicode server name to the scoreboard

### DIFF
--- a/cl_dll/vgui_ScorePanel.cpp
+++ b/cl_dll/vgui_ScorePanel.cpp
@@ -137,6 +137,14 @@ ScorePanel::ScorePanel(int x,int y,int wide,int tall) : Panel(x,y,wide,tall)
 	m_TitleLabel.setFgColor( Scheme::sc_primary1 );
 	m_TitleLabel.setContentAlignment( vgui::Label::a_west );
 
+	if (!UnicodeTextImage::shouldFallback())
+	{
+		m_pTitleImage = new UnicodeTextImage();
+		m_pTitleImage->setFont(m_UTitleFont, tfont);
+		m_pTitleImage->setColor(Scheme::sc_primary1);
+		m_TitleLabel.setImage(m_pTitleImage);
+	}
+
 	LineBorder *border = new LineBorder(Color(60, 60, 60, 128));
 	setBorder(border);
 	setPaintBorderEnabled(true);
@@ -268,6 +276,9 @@ ScorePanel::~ScorePanel()
 #endif
 	if (m_pFlagIcon)
 		delete m_pFlagIcon;
+
+	m_TitleLabel.setImage(nullptr);
+	delete m_pTitleImage;
 #ifdef POSIX
 #pragma GCC diagnostic pop
 #endif
@@ -304,7 +315,11 @@ void ScorePanel::Update()
 	// {
 		char sz[MAX_SERVERNAME_LENGTH + 16];
 		sprintf(sz, "%s", gViewPort->m_szServerName );
-		m_TitleLabel.setText(sz);
+
+		if (!m_pTitleImage->shouldFallback())
+			m_pTitleImage->setText(sz);
+		else
+			m_TitleLabel.setText(sz);
 	// }
 
 	m_iRows = 0;

--- a/cl_dll/vgui_ScorePanel.h
+++ b/cl_dll/vgui_ScorePanel.h
@@ -284,7 +284,7 @@ private:
 	UnicodeTextImage::HFont m_USmallFont;
 	UnicodeTextImage::HFont m_UTitleFont;
 
-	UnicodeTextImage *m_pTitleImage;
+	UnicodeTextImage *m_pTitleImage = nullptr;
 
 public:
 	

--- a/cl_dll/vgui_ScorePanel.h
+++ b/cl_dll/vgui_ScorePanel.h
@@ -284,6 +284,8 @@ private:
 	UnicodeTextImage::HFont m_USmallFont;
 	UnicodeTextImage::HFont m_UTitleFont;
 
+	UnicodeTextImage *m_pTitleImage;
+
 public:
 	
 	int				m_iNumTeams;


### PR DESCRIPTION
Replaces `vgui::TextImage` with `UnicodeTextImage` in scoreboard server name label. This adds Unicode support, anti-aliasing and high-resolution scaling to the server name shown in the scoreboard.

Before (rendered in 4K, downscaled to 1080p):
![crossfire0004](https://user-images.githubusercontent.com/20199236/96959319-f1d45900-1529-11eb-97f8-202d95d5f865.png)

After:
![crossfire0007](https://user-images.githubusercontent.com/20199236/96959335-fb5dc100-1529-11eb-9b84-fb644c99bd56.png)
