### PR TITLE
Scoreboard font fixes

### DIFF
--- a/cl_dll/vgui_SchemeManager.cpp
+++ b/cl_dll/vgui_SchemeManager.cpp
@@ -496,6 +496,11 @@ vgui::Font *CSchemeManager::getFont( SchemeHandle_t schemeHandle )
 	return getSafeScheme( schemeHandle )->font;
 }
 
+const char *CSchemeManager::getFontName( SchemeHandle_t schemeHandle )
+{
+	return getSafeScheme( schemeHandle )->fontName;
+}
+
 void CSchemeManager::getFgColor( SchemeHandle_t schemeHandle, int &r, int &g, int &b, int &a )
 {
 	CScheme *pScheme = getSafeScheme( schemeHandle );

--- a/cl_dll/vgui_SchemeManager.h
+++ b/cl_dll/vgui_SchemeManager.h
@@ -32,6 +32,7 @@ public:
 
 	// getting info from schemes
 	vgui::Font *getFont( SchemeHandle_t schemeHandle );
+	const char *getFontName( SchemeHandle_t schemeHandle );
 	void getFgColor( SchemeHandle_t schemeHandle, int &r, int &g, int &b, int &a );
 	void getBgColor( SchemeHandle_t schemeHandle, int &r, int &g, int &b, int &a );
 	void getFgArmedColor( SchemeHandle_t schemeHandle, int &r, int &g, int &b, int &a );

--- a/cl_dll/vgui_ScorePanel.cpp
+++ b/cl_dll/vgui_ScorePanel.cpp
@@ -62,8 +62,8 @@ public:
 SBColumnInfo g_ColumnInfo[NUM_COLUMNS] =
 {
 	{NULL,			24,			Label::a_east},		// tracker column
-	{NULL,			140,		Label::a_east},		// name
-	{"SteamID",		56,			Label::a_east},		// class
+	{NULL,			136,		Label::a_east},		// name
+	{"SteamID",		60,			Label::a_east},		// class
 	{"#SCORE",		40,			Label::a_east},
 	{"#DEATHS",		46,			Label::a_east},
 	{"#LATENCY",	46,			Label::a_east},

--- a/cl_dll/vgui_ScorePanel.cpp
+++ b/cl_dll/vgui_ScorePanel.cpp
@@ -98,27 +98,26 @@ void ScorePanel::HitTestPanel::internalMousePressed(MouseCode code)
 ScorePanel::ScorePanel(int x,int y,int wide,int tall) : Panel(x,y,wide,tall)
 {
 	CSchemeManager *pSchemes = gViewPort->GetSchemeManager();
+	SchemeHandle_t hScheme = pSchemes->getSchemeHandle("Scoreboard Text");
 	SchemeHandle_t hTitleScheme = pSchemes->getSchemeHandle("Scoreboard Title Text");
 	SchemeHandle_t hSmallScheme = pSchemes->getSchemeHandle("Scoreboard Small Text");
+	Font *sfont = pSchemes->getFont(hScheme);
 	Font *tfont = pSchemes->getFont(hTitleScheme);
 	Font *smallfont = pSchemes->getFont(hSmallScheme);
 
 	if (ScreenHeight > 768)
 	{
 		// Scale fonts for high-resolutions screens
-		m_UFont = UnicodeTextImage::createFont("Arial", std::round(YRES(10)), 300);
-		m_UTitleFont = UnicodeTextImage::createFont("Arial", std::round(YRES(16)), 700);
-		m_USmallFont = UnicodeTextImage::createFont("Arial", std::round(YRES(8)), 400);
+		m_UFont = UnicodeTextImage::createFont(pSchemes->getFontName(hScheme), std::round(YRES(10)), 300);
+		m_UTitleFont = UnicodeTextImage::createFont(pSchemes->getFontName(hTitleScheme), std::round(YRES(16)), 700);
+		m_USmallFont = UnicodeTextImage::createFont(pSchemes->getFontName(hSmallScheme), std::round(YRES(8)), 400);
 	}
 	else
 	{
 		// Use font sizes from the scheme for low resolutions (640x480, 800x600, 1024x768)
-		SchemeHandle_t hScheme = pSchemes->getSchemeHandle("Scoreboard Text");
-		Font *sfont = pSchemes->getFont(hScheme);
-
-		m_UFont = UnicodeTextImage::createFont("Arial", sfont->getTall(), 300);
-		m_UTitleFont = UnicodeTextImage::createFont("Arial", tfont->getTall(), 700);
-		m_USmallFont = UnicodeTextImage::createFont("Arial", smallfont->getTall(), 400);
+		m_UFont = UnicodeTextImage::createFont(pSchemes->getFontName(hScheme), sfont->getTall(), 300);
+		m_UTitleFont = UnicodeTextImage::createFont(pSchemes->getFontName(hTitleScheme), tfont->getTall(), 700);
+		m_USmallFont = UnicodeTextImage::createFont(pSchemes->getFontName(hSmallScheme), smallfont->getTall(), 400);
 	}
 
 	setBgColor(0, 0, 0, 96);

--- a/cl_dll/vgui_UnicodeTextImage.cpp
+++ b/cl_dll/vgui_UnicodeTextImage.cpp
@@ -368,6 +368,11 @@ UnicodeTextImage::HFont UnicodeTextImage::createFont(const char *fontName, int t
 	if (!g_bSurfaceLoaded)
 		return INVALID_FONT;
 
+#ifdef LINUX
+	// On linux fonts are 2px taller than they should be
+	tall -= 2;
+#endif
+
 	int flags = 0;
 	if (tall >= MIN_AA_FONT_SIZE)
 		flags |= vgui2::ISurface::FONTFLAG_ANTIALIAS;


### PR DESCRIPTION
1) Fonts on Linux are created 2px taller than they need to be so I added some code to compensate for that.
2) Widened SteamID column by 4px so long SteamIDs don't get clipped.
3) Font names are now loaded from current scheme file (XXX_textscheme.txt) to allow users to change fonts to different ones.