### PR TITLE
Fix incorrect handling of custom view models

### DIFF
--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -1436,13 +1436,24 @@ int V_FindViewModelByWeaponModel(int weaponindex)
 		int len = strlen( weaponModel->name );
 		int i = 0;
 
-		while ( modelmap[i] != NULL )
+		while ( modelmap[i][0] != NULL )
 		{
 			if ( !strnicmp( weaponModel->name, modelmap[i][0], len ) )
 			{
 				return gEngfuncs.pEventAPI->EV_FindModelIndex( modelmap[i][1] );
 			}
 			i++;
+		}
+
+		// Model name not found in the modelmap array (possible for WeaponMod weapons).
+		// Construct view model name based on player model name.
+		char buf[128];
+		safe_strcpy(buf, weaponModel->name, sizeof(buf));
+		if (!strncmp(buf, "models/p_", 9))
+		{
+			// Replace "models/p_" with "models/v_"
+			buf[7] = 'v';
+			return gEngfuncs.pEventAPI->EV_FindModelIndex(buf);
 		}
 
 		return 0;


### PR DESCRIPTION
This pull request fixes a few issues with `V_FindViewModelByWeaponModel` function.

1. Fix a crash when trying to find a custom model that is not on a hardcoded list.
2. If model was not found on the list (e.g. a custom WeaponMod weapon), it will attempt to convert player model name to a view model name ("models/p_weapon.mdl" -> "models/v_weapon.mdl"). It works most of the time but some weapons on some server use different names for world and view models (e.g. "p_dbarrel.mdl" and "v_dbarrel_hev.mdl"). In that case spectator won't see the view model.

Resolves #93