### PR TITLE
Proposal: Disable thirdperson

### DIFF
--- a/cl_dll/in_camera.cpp
+++ b/cl_dll/in_camera.cpp
@@ -1,4 +1,4 @@
-//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright ï¿½ 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //
@@ -426,15 +426,14 @@ void CAM_OutUp(void) { KeyUp( &cam_out ); }
 
 void CAM_ToThirdPerson(void)
 { 
-	vec3_t viewangles;
-
+	//Only allow cam_command if we are running a debug version of the client.dll
 #if !defined( _DEBUG )
-	if ( gEngfuncs.GetMaxClients() > 1 )
-	{
-		// no thirdperson in multiplayer.
-		return;
-	}
+	// Reset the cam_command cvar so this function isn't called on every think 
+	// if player used cam_command 1 and not thirdperson
+	gEngfuncs.Cvar_SetValue( "cam_command", 0 );
+	return;
 #endif
+	vec3_t viewangles;
 
 	gEngfuncs.GetViewAngles( (float *)viewangles );
 

--- a/cl_dll/in_camera.cpp
+++ b/cl_dll/in_camera.cpp
@@ -1,4 +1,4 @@
-//========= Copyright ï¿½ 1996-2002, Valve LLC, All rights reserved. ============
+//========= Copyright © 1996-2002, Valve LLC, All rights reserved. ============
 //
 // Purpose: 
 //
@@ -168,6 +168,8 @@ extern trace_t SV_ClipMoveToEntity (edict_t *ent, vec3_t start, vec3_t mins, vec
 void CL_DLLEXPORT CAM_Think( void )
 {
 //	RecClCamThink();
+	if ( gEngfuncs.GetMaxClients() > 1 && CL_IsThirdPerson() )
+		CAM_ToFirstPerson();
 
 	float cam_mouse_x, cam_mouse_y;
 	vec3_t origin;
@@ -426,14 +428,15 @@ void CAM_OutUp(void) { KeyUp( &cam_out ); }
 
 void CAM_ToThirdPerson(void)
 { 
-	//Only allow cam_command if we are running a debug version of the client.dll
-#if !defined( _DEBUG )
-	// Reset the cam_command cvar so this function isn't called on every think 
-	// if player used cam_command 1 and not thirdperson
-	gEngfuncs.Cvar_SetValue( "cam_command", 0 );
-	return;
-#endif
 	vec3_t viewangles;
+
+#if !defined( _DEBUG )
+	if ( gEngfuncs.GetMaxClients() > 1 )
+	{
+		// no thirdperson in multiplayer.
+		return;
+	}
+#endif
 
 	gEngfuncs.GetViewAngles( (float *)viewangles );
 


### PR DESCRIPTION
Hello.

First off, I am proposing this change to the client code, even though I am aware this should mainly be fixed server-side, the motivation for that is that for example Deathmath Classic and Ricochet don't suffer from this problem but also only fix it in the client library.

**Reason for this change/Motivation:**
Thirdperson can at the current state be potentially used to cheat in HLDM/AG without any modifications of the client DLL.
If you are on a maxplayers = 1 & deathmatch 0 server OR you are not connected at all and use these commands in the console:
```
sv_cheats 1
thirdperson // or cam_command 1
```
And then join a multiplayer AG server you will be in thirdperson mode, even though it normally isn't allowed, but the code in HLDM only checks after you type "thirdperson" **WHILE on a multiplayer server.** 

The game breaking part is pretty obvious, any players/entities that are in the player's PVS (from the origin they are standing at, not the camera's origin, thank god) are visible through walls.

See this video for examples: https://youtu.be/hyRp_ecrbGQ?t=78

This snippet from cl_dll/in_camera.cpp shows why you cannot switch to thirdperson once you are on a multiplayer server:
```
   368	void CAM_ToThirdPerson(void)
   369	{ 
   370		vec3_t viewangles;
       
   371	#if !defined( _DEBUG )
   372		if ( gEngfuncs.GetMaxClients() > 1 )
   373		{
   374			// no thirdperson in multiplayer.
   375			return;
   376		}
   377	#endif
```
But nothing in in_camera.cpp or anywhere else resets it or checks if you had it set up before you joined the server.

**Options (for client side):**
* a) Disable thirdperson altogether (like DMC does) aka this pull request's code
* * This disables the thirdperson and cam_command 1 (thirdperson) altogether and you cannot use it on a local singleplayer server.
* b) Only disable thirdperson by checking if the player is on a maxplayers > 1 server and if he's in thirdperson - for example in CAM_Think() in cl_dll/in_camera.cpp with something like:
```
if ( gEngfuncs.GetMaxClients() > 1 && CL_IsThirdPerson() )
		CAM_ToFirstPerson();
```
(Ricochet does this as part of its game - when you die in Ricochet it switches to thirdperson and vice versa, the side-effect is that this bug is fixed and you cannot switch to thirdperson)

Again, I understand this should be fixed serverside using AMXX/custom compiled server.so/dll library, but I feel like this is kind of a "first step" that can help as well (even though obviously players can just compile their own client / use the old ones and utilize this and hence should be fixed ASAP on all servers).

Thanks & review very welcome.

**EDIT:** I've been told this bug is even mentioned upstream: https://github.com/ValveSoftware/halflife/issues/2622 ages ago, so let's be better than upstream and actually fix it :^) I don't even wanna bother PRing it to upstream seeing as YaLTeR has 3 PRs still open from 2015(!), lol.