### PR TITLE
Fixed HUD align bug in ammo history for ammo < 10 (#54)

### DIFF
--- a/cl_dll/ammohistory.cpp
+++ b/cl_dll/ammohistory.cpp
@@ -138,7 +138,9 @@ int HistoryResource :: DrawAmmoHistory( float flTime )
 				}
 
 				// Draw the number
-				gHUD.DrawHudNumberString( xpos - 10, ypos, xpos - 100, rgAmmoHistory[i].iCount, r, g, b );
+				char szString[32];
+				snprintf( szString, ARRAYSIZE(szString), "%d", rgAmmoHistory[i].iCount );
+				gHUD.DrawHudStringRightAligned( xpos - 10, ypos, szString, r, g, b );
 			}
 			else if ( rgAmmoHistory[i].type == HISTSLOT_WEAP )
 			{


### PR DESCRIPTION
Fixes #54 

**Screenshots:**
![image](https://user-images.githubusercontent.com/5108747/115100717-b21d8580-9f3e-11eb-8a49-b4a96a2f7930.png)
![image](https://user-images.githubusercontent.com/5108747/115100764-16d8e000-9f3f-11eb-80b1-befc3233c7b4.png)

