### PR TITLE
Implement cl_old_scoreboard

### DIFF
--- a/cl_dll/CMakeLists.txt
+++ b/cl_dll/CMakeLists.txt
@@ -78,6 +78,8 @@ add_sources(
 	hud_vote.h
 	hud_watermark.cpp
 	hud_watermark.h
+	hud_oldscoreboard.cpp
+	hud_oldscoreboard.h
 	hudgl.cpp
 	hudgl.h
 	in_camera.cpp

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -575,6 +575,7 @@ void CHud :: Init( void )
 	m_Timer.Init();
 	m_Vote.Init();
 	m_Watermark.Init();
+	m_OldScoreBoard.Init();
 	GetClientVoiceMgr()->Init(&g_VoiceStatusHelper, (vgui::Panel**)&gViewPort);
 
 	m_Menu.Init();
@@ -740,6 +741,7 @@ void CHud :: VidInit( void )
 	m_Timer.VidInit();
 	m_Vote.VidInit();
 	m_Watermark.VidInit();
+	m_OldScoreBoard.VidInit();
 	GetClientVoiceMgr()->VidInit();
 }
 

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -99,6 +99,7 @@ struct HUDLIST {
 #include "hud_debug.h"
 #include "hud_location.h"
 #include "hud_nextmap.h"
+#include "hud_oldscoreboard.h"
 #include "hud_playerid.h"
 #include "hud_scores.h"
 #include "hud_settings.h"
@@ -605,6 +606,7 @@ public:
 	int DrawHudString(int x, int y, int iMaxX, const char *szString, int r, int g, int b );
 	int DrawHudStringReverse( int xpos, int ypos, int iMinX, const char *szString, int r, int g, int b );
 	int DrawHudNumberString( int xpos, int ypos, int iMinX, int iNumber, int r, int g, int b );
+	int DrawHudNumberStringFixed( int xpos, int ypos, int iNumber, int r, int g, int b );
 	int GetNumWidth(int iNumber, int iFlags);
 
 	int DrawHudStringCentered(int x, int y, const char* string, int r, int g, int b);
@@ -685,6 +687,7 @@ public:
 	CHudTimer		m_Timer;
 	CHudVote		m_Vote;
 	CHudWatermark	m_Watermark;
+	CHudOldScoreboard m_OldScoreBoard;
 
 	CRainbow m_Rainbow;
 

--- a/cl_dll/hud_oldscoreboard.cpp
+++ b/cl_dll/hud_oldscoreboard.cpp
@@ -6,6 +6,7 @@
 #include "vgui_TeamFortressViewport.h"
 #include "hud_oldscoreboard.h"
 #include "vgui_ScorePanel.h"
+#include "steam_id.h"
 
 // Y positions
 // Those who play on killed-off 32bit Apple don't deserve old_scoreboard looking good
@@ -240,7 +241,14 @@ int CHudOldScoreboard::Draw(float fTime)
 
 			char szName[128];
 			int specoffset = 0;
-			snprintf(szName, ARRAYSIZE(szName), "%s", pl_info->name);
+			const char* name = nullptr;
+
+			if (steam_id::is_showing_real_names())
+				name = steam_id::get_real_name(scoreboard->m_iSortedRows[iRow] - 1).c_str();
+			if (!name || name[0] == '\0')
+				name = pl_info->name;
+
+			snprintf(szName, ARRAYSIZE(szName), "%s", name);
 
 			// If this player is a spectator we need to also fit " (S)" in, let's prepare for that
 			if (g_IsSpectator[scoreboard->m_iSortedRows[iRow]])

--- a/cl_dll/hud_oldscoreboard.cpp
+++ b/cl_dll/hud_oldscoreboard.cpp
@@ -260,8 +260,8 @@ int CHudOldScoreboard::Draw(float fTime)
 				std::string spec_str(" (S)");
 				for( char& c : spec_str )
 				{
-					auto width = gHUD.m_scrinfo.charWidths[ static_cast<unsigned char>(c) ];
-					specoffset += width;
+					auto cwidth = gHUD.m_scrinfo.charWidths[ static_cast<unsigned char>(c) ];
+					specoffset += cwidth;
 				}
 			}
 
@@ -273,13 +273,7 @@ int CHudOldScoreboard::Draw(float fTime)
 
 			// Now that we have space for it, add the (S)
 			if (g_IsSpectator[scoreboard->m_iSortedRows[iRow]])
-			{
-				auto len = strlen(szName);
-				szName[len - 1] = ')';
-				szName[len - 2] = 'S';
-				szName[len - 3] = '(';
-				szName[len - 4] = ' ';
-			}
+				strcat(szName, " (S)");
 
 			gHUD.DrawHudStringWithColorTags(xpos + nameoffset, ypos, szName, r, g, b);
 

--- a/cl_dll/hud_oldscoreboard.cpp
+++ b/cl_dll/hud_oldscoreboard.cpp
@@ -85,17 +85,12 @@ void CHudOldScoreboard::ShowScoreboard(bool bShow)
 
 int CHudOldScoreboard::Draw(float fTime)
 {
-	// Let users use 320 even on Linux, if they really want to
-	if (m_pCvarOldScoreboardWidth->value < 320.0f || m_pCvarOldScoreboardWidth->value > ScreenWidth)
-	{
-		gEngfuncs.Con_Printf("Invalid cl_oldscoreboard_width value (%d) ", (int)m_pCvarOldScoreboardWidth->value);
-		gEngfuncs.Con_Printf("(minimum = %d, maximum = %d (current screen width))\n", 320, ScreenWidth);
-		gEngfuncs.Con_Printf("Resetting to default: %s\n", DEFAULT_WIDTH);
-		gEngfuncs.Cvar_SetValue("cl_old_scoreboard_width", DEFAULT_WIDTH_NUM);
-	}
-
 	if (!IsVisible())
 		return 1;
+
+	// Let users use 320 even on Linux, if they really want to
+	int width = max(min((int)m_pCvarOldScoreboardWidth->value, ScreenWidth), 320);
+	m_WidthScale = (float)width / 320.0f;
 
 	/*
 	 * X positions, relative to the side of the scoreboard
@@ -103,8 +98,6 @@ int CHudOldScoreboard::Draw(float fTime)
 	 * And yes, the original scoreboard isn't perfectly centered,
 	 * even that is preserved :)
 	 */
-	m_WidthScale = m_pCvarOldScoreboardWidth->value / 320.0f;
-
 	int NAME_RANGE_MIN = 20 * m_WidthScale;
 	int NAME_RANGE_MAX = 145 * m_WidthScale;
 	int KILLS_RANGE_MIN = 130 * m_WidthScale;
@@ -121,7 +114,7 @@ int CHudOldScoreboard::Draw(float fTime)
 	int xpos = 0;
 	int ypos = 0;
 	float list_slot = 0;
-	int xpos_rel = (ScreenWidth - (int)m_pCvarOldScoreboardWidth->value) / 2; // scale the scoreboard based on the cvar
+	int xpos_rel = (ScreenWidth - width) / 2; // scale the scoreboard based on the cvar
 
 	// print the heading line
 	ypos = ROW_TOP + ROW_RANGE_MIN + (list_slot * ROW_GAP);
@@ -140,7 +133,7 @@ int CHudOldScoreboard::Draw(float fTime)
 	gHUD.DrawHudString(DEATHS_RANGE_MIN + xpos_rel, ypos, ScreenWidth, CHudTextMessage::BufferedLocaliseTextString("#DEATHS"), r, g, b);
 
 	// can't use #LATENCY as RightAligned is not a friend with BufferedLocaliseTextString for some reason, sorry
-	xpos = m_pCvarOldScoreboardWidth->value + xpos_rel - (m_pCvarOldScoreboardWidth->value - END);
+	xpos = width + xpos_rel - (width - END);
 	gHUD.DrawHudStringRightAligned(xpos, ypos, "Ping/loss", r, g, b);
 
 	list_slot += 1.5;
@@ -298,7 +291,7 @@ int CHudOldScoreboard::Draw(float fTime)
 
 			// draw ping & packetloss
 			// Why 25: 320 (default width in the original AG) - 295 (PING_RANGE_MAX) = 25
-			xpos = m_pCvarOldScoreboardWidth->value + xpos_rel - (m_pCvarOldScoreboardWidth->value - PING_RANGE_MAX);
+			xpos = width + xpos_rel - (width - PING_RANGE_MAX);
 			static char buf[64];
 			snprintf(buf, ARRAYSIZE(buf), "%d/%d", (int)pl_info->ping, (int)pl_info->packetloss);
 			gHUD.DrawHudStringRightAligned(xpos , ypos, buf, r, g, b);

--- a/cl_dll/hud_oldscoreboard.cpp
+++ b/cl_dll/hud_oldscoreboard.cpp
@@ -29,7 +29,6 @@
 
 #define ROW_GAP (gHUD.m_scrinfo.iCharHeight - 5)
 #define ROW_RANGE_MAX ( ScreenHeight - 50 )
-#define ROW_TOP 40
 
 #define TEAM_NO             0
 #define TEAM_YES            1
@@ -85,6 +84,11 @@ int CHudOldScoreboard::Draw(float fTime)
 {
 	if (!IsVisible())
 		return 1;
+
+	// This is now calculated so that the HLKreedz timer is not in the way on ANY resolution
+	// Since the Y pos of the timer is changed with different resolution
+	// It's also calculated dynamically since one can change the ScreenHeight by resizing the window during game
+	int ROW_TOP = (ScreenHeight / 320.0f) * 30.0f;
 
 	// Let users use 320 even on Linux, if they really want to
 	int width = max(min((int)m_pCvarOldScoreboardWidth->value, ScreenWidth), 320);

--- a/cl_dll/hud_oldscoreboard.cpp
+++ b/cl_dll/hud_oldscoreboard.cpp
@@ -21,11 +21,9 @@
 	 * LINUX = Trebuchet MS = 11x10
 	 */
 	#define DEFAULT_WIDTH "380"
-	#define DEFAULT_WIDTH_NUM 380
 #else
 	#define ROW_RANGE_MIN (gHUD.m_scrinfo.iCharHeight + 2)
 	#define DEFAULT_WIDTH "320"
-	#define DEFAULT_WIDTH_NUM 320
 #endif // LINUX
 
 #define ROW_GAP (gHUD.m_scrinfo.iCharHeight - 5)
@@ -41,7 +39,6 @@ int CHudOldScoreboard::Init(void)
 {
 	m_pCvarOldScoreboard = CVAR_CREATE("cl_old_scoreboard", "0", FCVAR_ARCHIVE);
 	m_pCvarOldScoreboardWidth = CVAR_CREATE("cl_old_scoreboard_width", DEFAULT_WIDTH, FCVAR_ARCHIVE);
-	m_pCvarOldScoreboardColorsTags = CVAR_CREATE("cl_old_scoreboard_colortags", "0", FCVAR_ARCHIVE);
 
 	m_iFlags = 0;
 
@@ -271,9 +268,6 @@ int CHudOldScoreboard::Draw(float fTime)
 				szName[len - 3] = '(';
 				szName[len - 4] = ' ';
 			}
-
-			if (m_pCvarOldScoreboardColorsTags->value == 0.0f)
-				color_tags::strip_color_tags(szName, szName, ARRAYSIZE(szName));
 
 			gHUD.DrawHudStringWithColorTags(xpos + nameoffset, ypos, szName, r, g, b);
 

--- a/cl_dll/hud_oldscoreboard.cpp
+++ b/cl_dll/hud_oldscoreboard.cpp
@@ -1,0 +1,309 @@
+#include "hud.h"
+#include "cl_util.h"
+#include <string.h>
+#include <stdio.h>
+#include <demo_api.h>
+#include "vgui_TeamFortressViewport.h"
+#include "hud_oldscoreboard.h"
+#include "vgui_ScorePanel.h"
+
+// Y positions
+// Those who play on killed-off 32bit Apple don't deserve old_scoreboard looking good
+// as I am too lazy to build & test in a MacOS, sorry.
+#ifdef LINUX
+	#define ROW_GAP (gHUD.m_scrinfo.iCharHeight - 5)
+	#define ROW_RANGE_MIN (gHUD.m_scrinfo.iCharHeight + 3)
+
+	/* The scoreboard's default width is set to 380 on Linux
+	 * since it doesn't look good (Ping/loss doesn't fit and overlaps "Deaths" etc.)
+	 * on the (original) 320 default, like it does on Windows,
+	 * since the engine's Trebuchet MS is bigger than on Windows
+	 * WINDOWS = Trebuchet MS = 9x8
+	 * LINUX = Trebuchet MS = 11x10
+	 */
+	#define DEFAULT_WIDTH "380"
+	#define DEFAULT_WIDTH_NUM 380
+#else
+	#define ROW_GAP  (gHUD.m_scrinfo.iCharHeight - 5)
+	#define ROW_RANGE_MIN (gHUD.m_scrinfo.iCharHeight + 2)
+	#define DEFAULT_WIDTH "320"
+	#define DEFAULT_WIDTH_NUM 320
+#endif // LINUX
+
+#define ROW_RANGE_MAX ( ScreenHeight - 50 )
+#define ROW_TOP 40
+
+#define TEAM_NO				0
+#define TEAM_YES			1
+#define TEAM_SPECTATORS		2
+#define TEAM_BLANK			3
+
+int CHudOldScoreboard::Init(void)
+{
+	m_pCvarOldScoreboard = CVAR_CREATE("cl_old_scoreboard", "0", FCVAR_ARCHIVE);
+	m_pCvarOldScoreboardWidth = CVAR_CREATE("cl_old_scoreboard_width", DEFAULT_WIDTH, FCVAR_ARCHIVE);
+
+	m_bShowScoreboard = false;
+	m_iFlags = 0;
+
+	gHUD.AddHudElem(this);
+	return 1;
+};
+
+int CHudOldScoreboard::VidInit(void)
+{
+	m_iFlags |= HUD_ACTIVE;
+	m_iFlags |= HUD_INTERMISSION; // is always drawn during an intermission
+
+	int m_iSprite = 0;
+	m_iSprite = gHUD.GetSpriteIndex("icon_ctf_score");
+	m_IconFlagScore.spr = gHUD.GetSprite(m_iSprite);
+	m_IconFlagScore.rc = gHUD.GetSpriteRect(m_iSprite);
+	m_WidthScale = m_pCvarOldScoreboardWidth->value / 320.0f;
+	m_bShowScoreboard = false;
+
+	return 1;
+}
+
+void CHudOldScoreboard::Reset(void)
+{
+
+}
+
+bool CHudOldScoreboard::IsVisible()
+{
+	return m_bShowScoreboard;
+}
+
+void CHudOldScoreboard::ShowScoreboard(bool bShow)
+{
+	if (bShow && gViewPort && gViewPort->m_pScoreBoard)
+		gViewPort->m_pScoreBoard->RebuildTeams();
+	m_bShowScoreboard = bShow;
+}
+
+int CHudOldScoreboard::Draw(float fTime)
+{
+	// Let users use 320 even on Linux, if they really want to
+	if (m_pCvarOldScoreboardWidth->value < 320.0f || m_pCvarOldScoreboardWidth->value > ScreenWidth)
+	{
+		gEngfuncs.Con_Printf("Invalid cl_oldscoreboard_width value (%d) ", (int)m_pCvarOldScoreboardWidth->value);
+		gEngfuncs.Con_Printf("(minimum = %d, maximum = %d (current screen width)\n", 320, ScreenWidth);
+		gEngfuncs.Con_Printf("Resetting to default: %s\n", DEFAULT_WIDTH);
+		m_pCvarOldScoreboardWidth->value = (float)DEFAULT_WIDTH_NUM;
+	}
+
+	if (!IsVisible())
+		return 1;
+
+	/*
+	 * X positions, relative to the side of the scoreboard
+	 * This is as close to the original as we can get more or less
+	 * And yes, the original scoreboard isn't perfectly centered,
+	 * even that is preserved :)
+	 */
+	m_WidthScale = m_pCvarOldScoreboardWidth->value / 320.0f;
+
+	int NAME_RANGE_MIN = 20 * m_WidthScale;
+	int NAME_RANGE_MAX = 145 * m_WidthScale;
+	int KILLS_RANGE_MIN = 130 * m_WidthScale;
+	int KILLS_RANGE_MAX = 160 * m_WidthScale;
+	int DIVIDER_POS     = 180 * m_WidthScale;
+	int DEATHS_RANGE_MIN = 190 * m_WidthScale; // og 185
+	int DEATHS_RANGE_MAX = 220 * m_WidthScale;
+	// int PING_RANGE_MIN  = 245 * m_WidthScale;
+	int PING_RANGE_MAX  = 295 * m_WidthScale;
+	int END = 315 * m_WidthScale;
+
+	int r, g, b;
+	UnpackRGB(r,g,b, gHUD.m_iDefaultHUDColor);
+
+	int xpos = 0;
+	int ypos = 0;
+	float list_slot = 0;
+	int xpos_rel = (ScreenWidth - (int)m_pCvarOldScoreboardWidth->value) / 2; // scale the scoreboard based on the cvar
+
+	// print the heading line
+	ypos = ROW_TOP + ROW_RANGE_MIN + (list_slot * ROW_GAP);
+	xpos = NAME_RANGE_MIN + xpos_rel;
+
+	if (!gHUD.m_Teamplay)
+		gHUD.DrawHudString(xpos, ypos, NAME_RANGE_MAX + xpos_rel, CHudTextMessage::BufferedLocaliseTextString("#PLAYERS"), r, g, b);
+	else
+		gHUD.DrawHudString(xpos, ypos, NAME_RANGE_MAX + xpos_rel, CHudTextMessage::BufferedLocaliseTextString("#TEAMS"), r, g, b);
+
+	// can't use #SCORE as RightAligned is not a friend with BufferedLocaliseTextString for some reason, sorry
+	gHUD.DrawHudStringRightAligned( KILLS_RANGE_MAX + xpos_rel, ypos, CHudTextMessage::BufferedLocaliseTextString("Score"), r, g, b);
+
+	gHUD.DrawHudStringCentered(DIVIDER_POS + xpos_rel, ypos, "/", r, g, b);
+
+	gHUD.DrawHudString(DEATHS_RANGE_MIN + xpos_rel, ypos, ScreenWidth, CHudTextMessage::BufferedLocaliseTextString("#DEATHS"), r, g, b);
+
+	// can't use #LATENCY as RightAligned is not a friend with BufferedLocaliseTextString for some reason, sorry
+	xpos = m_pCvarOldScoreboardWidth->value + xpos_rel - (m_pCvarOldScoreboardWidth->value - END);
+	gHUD.DrawHudStringRightAligned(xpos, ypos, "Ping/loss", r, g, b);
+
+	list_slot += 1.5;
+	ypos = ROW_TOP + ROW_RANGE_MIN + (list_slot * ROW_GAP);
+	xpos = NAME_RANGE_MIN + xpos_rel;
+	FillRGBA( xpos, ypos, PING_RANGE_MAX, 1, r, g, b, 255); // draw the seperator line
+
+	list_slot += 0.8;
+
+	// draw the players, in order
+	const auto scoreboard = gViewPort->GetScoreBoard();
+	gViewPort->GetAllPlayersInfo();
+
+	for (int iRow = 0; iRow < scoreboard->m_iRows; ++iRow)
+	{
+		const auto sorted = scoreboard->m_iSortedRows[iRow];
+		int nameoffset = 0;
+
+		if (scoreboard->m_iIsATeam[iRow] == TEAM_BLANK)
+			continue;
+
+		else if (scoreboard->m_iIsATeam[iRow] && gHUD.m_Teamplay)
+		{
+			// Draw team info line
+			team_info_t* team_info = &g_TeamInfo[sorted];
+
+			if (0 != iRow)
+				list_slot += 0.3;
+			ypos = ROW_TOP + ROW_RANGE_MIN + (list_slot * ROW_GAP);
+
+			// check we haven't drawn too far down
+			if ( ypos > ROW_RANGE_MAX )  // don't draw to close to the lower border
+				break;
+
+			xpos = NAME_RANGE_MIN + xpos_rel;
+
+			char szTeamName[128];
+			if (scoreboard->m_iIsATeam[iRow] == TEAM_SPECTATORS)
+			{
+				r = g = b = 100;
+				snprintf(szTeamName, ARRAYSIZE(szTeamName), "%s", CHudTextMessage::BufferedLocaliseTextString( "#Spectators"));
+			}
+			else
+			{
+				r = iTeamColors[team_info->teamnumber % iNumberOfTeamColors][0];
+				g = iTeamColors[team_info->teamnumber % iNumberOfTeamColors][1];
+				b = iTeamColors[team_info->teamnumber % iNumberOfTeamColors][2];
+				snprintf(szTeamName, ARRAYSIZE(szTeamName), "%s", team_info->name);
+			}
+
+			// Cut off the name if it'd overlap score
+			// - 5 to allow for some more space between the name and kills
+			while ( gHUD.GetHudStringWidth(szTeamName) + nameoffset + NAME_RANGE_MIN > KILLS_RANGE_MIN - 5 )
+			{
+				szTeamName[strlen(szTeamName) - 1] = '\0';
+			}
+			// draw their name (left to right)
+			gHUD.DrawHudString(xpos, ypos, 0, szTeamName, r, g, b);
+
+			// draw kills (right to left)
+			xpos = KILLS_RANGE_MAX + xpos_rel;
+			gHUD.DrawHudNumberStringFixed(xpos, ypos, team_info->frags, r, g, b);
+
+			// draw divider
+			xpos = DIVIDER_POS + xpos_rel;
+			gHUD.DrawHudStringCentered(xpos, ypos, "/", r, g, b);
+
+			// draw deaths
+			xpos = DEATHS_RANGE_MAX + xpos_rel;
+			gHUD.DrawHudNumberStringFixed(xpos, ypos, team_info->deaths, r, g, b);
+			list_slot++;
+		}
+		else
+		{
+			// Draw player info line
+			if (gHUD.m_Teamplay)
+				nameoffset = 10;
+
+			hud_player_info_t* pl_info = &g_PlayerInfoList[sorted];
+			extra_player_info_t* pl_info_extra = &g_PlayerExtraInfo[sorted];
+
+			ypos = ROW_TOP + ROW_RANGE_MIN + (list_slot * ROW_GAP);
+
+			// check we haven't drawn too far down
+			if ( ypos > ROW_RANGE_MAX )  // don't draw to close to the lower border
+				break;
+
+			r = iTeamColors[pl_info_extra->teamnumber % iNumberOfTeamColors][0];
+			g = iTeamColors[pl_info_extra->teamnumber % iNumberOfTeamColors][1];
+			b = iTeamColors[pl_info_extra->teamnumber % iNumberOfTeamColors][2];
+
+			xpos = NAME_RANGE_MIN + xpos_rel; // Set xpos for name here so that the flag is at the correct position
+
+			// If this player is carrying a CTF flag, draw the sprite for it
+			if (gHUD.m_CTF.GetBlueFlagPlayerIndex() == sorted || gHUD.m_CTF.GetRedFlagPlayerIndex() == sorted)
+			{
+				SPR_Set(m_IconFlagScore.spr, 200, 200, 200);
+				SPR_DrawAdditive(0, xpos - 10, ypos + 5, &m_IconFlagScore.rc);
+			}
+
+			if (pl_info->thisplayer) // if it's local player's name, draw it with a different color
+			{
+				r = g = b = 255;
+				// overlay the background in blue, then draw the score text over it
+				FillRGBA( NAME_RANGE_MIN + xpos_rel - 5, ypos + 5, PING_RANGE_MAX - 5, ROW_GAP, 0, 0, 255, 70);
+			}
+
+			char szName[128];
+			char colorlessName[128];
+			int specoffset = 0;
+			snprintf(szName, ARRAYSIZE(szName), "%s", pl_info->name);
+			color_tags::strip_color_tags(colorlessName, szName, ARRAYSIZE(colorlessName));
+
+			// If this player is a spectator we need to also fit " (S)" in, let's prepare for that
+			if (g_IsSpectator[scoreboard->m_iSortedRows[iRow]])
+			{
+				std::string spec_str(" (S)");
+				for( char& c : spec_str )
+				{
+					auto width = gHUD.m_scrinfo.charWidths[ static_cast<unsigned char>(c) ];
+					specoffset += width;
+				}
+			}
+
+			// cut off the name if it'd overlap score
+			while ( gHUD.GetHudStringWidth(colorlessName) + nameoffset + NAME_RANGE_MIN > KILLS_RANGE_MIN )
+			{
+				colorlessName[strlen(colorlessName) - 1] = '\0';
+			}
+
+			// Now that we have space for it, add the (S)
+			if (g_IsSpectator[scoreboard->m_iSortedRows[iRow]])
+			{
+				colorlessName[strlen(colorlessName) - 1] = ')';
+				colorlessName[strlen(colorlessName) - 2] = 'S';
+				colorlessName[strlen(colorlessName) - 3] = '(';
+				colorlessName[strlen(colorlessName) - 4] = ' ';
+			}
+
+			gHUD.DrawHudStringWithColorTags(xpos + nameoffset, ypos, colorlessName, r, g, b);
+
+			// draw kills (right to left)
+			xpos = KILLS_RANGE_MAX + xpos_rel;
+			gHUD.DrawHudNumberStringFixed(xpos, ypos, pl_info_extra->frags, r, g, b);
+
+			// draw divider
+			xpos = DIVIDER_POS + xpos_rel;
+			gHUD.DrawHudStringCentered(xpos, ypos, "/", r, g, b);
+
+			// draw deaths
+			xpos = DEATHS_RANGE_MAX + xpos_rel;
+			gHUD.DrawHudNumberStringFixed(xpos, ypos, pl_info_extra->deaths, r, g, b);
+
+			// draw ping & packetloss
+			// Why 25: 320 (default width in the original AG) - 295 (PING_RANGE_MAX) = 25
+			xpos = m_pCvarOldScoreboardWidth->value + xpos_rel - (m_pCvarOldScoreboardWidth->value - PING_RANGE_MAX);
+			static char buf[64];
+			sprintf(buf, "%d/%d", (int)pl_info->ping, (int)pl_info->packetloss);
+			gHUD.DrawHudStringRightAligned(xpos , ypos, buf, r, g, b);
+
+			list_slot++;
+		}
+	}
+
+	return 1;
+}

--- a/cl_dll/hud_oldscoreboard.h
+++ b/cl_dll/hud_oldscoreboard.h
@@ -14,7 +14,7 @@ public:
 	void Reset( void );
 
 	bool IsVisible( );
-	void ShowScoreboard( bool bShow = true );
+	void ShowScoreboard( bool bShow );
 private:
 	typedef struct
 	{

--- a/cl_dll/hud_oldscoreboard.h
+++ b/cl_dll/hud_oldscoreboard.h
@@ -1,0 +1,36 @@
+#ifndef OLDSCOREBOARD_H
+#define OLDSCOREBOARD_H
+#pragma once
+
+#include "cl_entity.h"
+#include "interpolation.h"
+
+class CHudOldScoreboard: public CHudBase
+{
+public:
+	int Init( void );
+	int VidInit( void );
+	int Draw( float flTime );
+	void Reset( void );
+
+	bool IsVisible( );
+	void ShowScoreboard( bool bShow = true );
+private:
+	typedef struct
+	{
+		HSPRITE spr;
+		wrect_t rc;
+	} icon_flagstatus_t;
+
+	icon_flagstatus_t m_IconFlagScore;
+
+	bool m_bShowScoreboard;
+
+	cvar_t *m_pCvarOldScoreboard;
+	cvar_t *m_pCvarOldScoreboardWidth;
+
+	float m_WidthScale;
+
+};
+
+#endif //OLD_SCOREBOARD_H

--- a/cl_dll/hud_oldscoreboard.h
+++ b/cl_dll/hud_oldscoreboard.h
@@ -26,6 +26,7 @@ private:
 
 	cvar_t *m_pCvarOldScoreboard;
 	cvar_t *m_pCvarOldScoreboardWidth;
+	cvar_t *m_pCvarOldScoreboardColorsTags;
 
 	float m_WidthScale;
 };

--- a/cl_dll/hud_oldscoreboard.h
+++ b/cl_dll/hud_oldscoreboard.h
@@ -24,13 +24,10 @@ private:
 
 	icon_flagstatus_t m_IconFlagScore;
 
-	bool m_bShowScoreboard;
-
 	cvar_t *m_pCvarOldScoreboard;
 	cvar_t *m_pCvarOldScoreboardWidth;
 
 	float m_WidthScale;
-
 };
 
 #endif //OLD_SCOREBOARD_H

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -293,6 +293,13 @@ int CHud :: DrawHudNumberString( int xpos, int ypos, int iMinX, int iNumber, int
 
 }
 
+int CHud :: DrawHudNumberStringFixed( int xpos, int ypos, int iNumber, int r, int g, int b )
+{
+	char szString[32];
+	sprintf( szString, "%d", iNumber );
+	return DrawHudStringRightAligned( xpos, ypos, szString, r, g, b );
+}
+
 // draws a string from right to left (right-aligned)
 int CHud :: DrawHudStringReverse( int xpos, int ypos, int iMinX, const char *szString, int r, int g, int b )
 {

--- a/cl_dll/vgui_TeamFortressViewport.cpp
+++ b/cl_dll/vgui_TeamFortressViewport.cpp
@@ -1414,7 +1414,6 @@ void TeamFortressViewport::ShowScoreBoard( void )
 			{
 				gHUD.m_OldScoreBoard.ShowScoreboard(false);
 				m_pScoreBoard->Open();
-				UpdateCursorState();
 			}
 			UpdateCursorState(); // just to be sure I guess
 		}

--- a/cl_dll/vgui_TeamFortressViewport.cpp
+++ b/cl_dll/vgui_TeamFortressViewport.cpp
@@ -1403,8 +1403,21 @@ void TeamFortressViewport::ShowScoreBoard( void )
 		// No Scoreboard in single-player
 		if ( gEngfuncs.GetMaxClients() > 1 )
 		{
-			m_pScoreBoard->Open();
-			UpdateCursorState();
+			// The user can change the scoreboard style while the scoreboard is being "drawn" (e.g. when togglescores is on)
+			// Therefore make sure to close/hide the other one first
+			if (CVAR_GET_FLOAT("cl_old_scoreboard") == 1)
+			{
+				m_pScoreBoard->setVisible(false);
+				m_pScoreBoard->RebuildTeams(); // TODO: is this needed?
+				gHUD.m_OldScoreBoard.ShowScoreboard(true);
+				UpdateCursorState(); // just to be sure I guess
+			}
+			else
+			{
+				gHUD.m_OldScoreBoard.ShowScoreboard(false);
+				m_pScoreBoard->Open();
+				UpdateCursorState();
+			}
 		}
 	}
 }
@@ -1415,7 +1428,12 @@ void TeamFortressViewport::ShowScoreBoard( void )
 bool TeamFortressViewport::IsScoreBoardVisible( void )
 {
 	if (m_pScoreBoard)
-		return m_pScoreBoard->isVisible();
+	{
+		if (CVAR_GET_FLOAT("cl_old_scoreboard") == 1)
+			return gHUD.m_OldScoreBoard.IsVisible();
+		else
+			return m_pScoreBoard->isVisible();
+	}
 
 	return false;
 }
@@ -1428,6 +1446,14 @@ void TeamFortressViewport::HideScoreBoard( void )
 	// Prevent removal of scoreboard during intermission
 	if ( gHUD.m_iIntermission )
 		return;
+
+	// The user can change the scoreboard style while the scoreboard is being "drawn" (e.g. when togglescores is on)
+	// Therefore hide both of them so that we are sure we aren't drawing both of them
+
+	if ( CVAR_GET_FLOAT("cl_old_scoreboard") == 1 )
+	{
+		gHUD.m_OldScoreBoard.ShowScoreboard(false);
+	}
 
 	if (m_pScoreBoard)
 	{

--- a/cl_dll/vgui_TeamFortressViewport.cpp
+++ b/cl_dll/vgui_TeamFortressViewport.cpp
@@ -1405,12 +1405,10 @@ void TeamFortressViewport::ShowScoreBoard( void )
 		{
 			// The user can change the scoreboard style while the scoreboard is being "drawn" (e.g. when togglescores is on)
 			// Therefore make sure to close/hide the other one first
-			if (CVAR_GET_FLOAT("cl_old_scoreboard") == 1)
+			if (CVAR_GET_FLOAT("cl_old_scoreboard") != 0)
 			{
 				m_pScoreBoard->setVisible(false);
-				m_pScoreBoard->RebuildTeams(); // TODO: is this needed?
 				gHUD.m_OldScoreBoard.ShowScoreboard(true);
-				UpdateCursorState(); // just to be sure I guess
 			}
 			else
 			{
@@ -1418,6 +1416,7 @@ void TeamFortressViewport::ShowScoreBoard( void )
 				m_pScoreBoard->Open();
 				UpdateCursorState();
 			}
+			UpdateCursorState(); // just to be sure I guess
 		}
 	}
 }
@@ -1429,7 +1428,7 @@ bool TeamFortressViewport::IsScoreBoardVisible( void )
 {
 	if (m_pScoreBoard)
 	{
-		if (CVAR_GET_FLOAT("cl_old_scoreboard") == 1)
+		if (CVAR_GET_FLOAT("cl_old_scoreboard") != 0)
 			return gHUD.m_OldScoreBoard.IsVisible();
 		else
 			return m_pScoreBoard->isVisible();
@@ -1447,17 +1446,10 @@ void TeamFortressViewport::HideScoreBoard( void )
 	if ( gHUD.m_iIntermission )
 		return;
 
-	// The user can change the scoreboard style while the scoreboard is being "drawn" (e.g. when togglescores is on)
-	// Therefore hide both of them so that we are sure we aren't drawing both of them
-
-	if ( CVAR_GET_FLOAT("cl_old_scoreboard") == 1 )
-	{
-		gHUD.m_OldScoreBoard.ShowScoreboard(false);
-	}
-
 	if (m_pScoreBoard)
 	{
 		m_pScoreBoard->setVisible(false);
+		gHUD.m_OldScoreBoard.ShowScoreboard(false);
 
 		GetClientVoiceMgr()->StopSquelchMode();
 


### PR DESCRIPTION
This closes #89.

Oof, I might finally finish this. 

This is based on the original AG old scoreboard (which is based on the old HL scoreboard).
I've tried to stick as close to the original as I could but at the same time I wanted to improve a few things, one of them being rendering this somewhat accurately and be usable on Linux as well. Therefore I have made some alternative design (positioning mainly) choices. I've also introduced a `cl_oldscoreboard_width` cvar where the motivation was that since the width is already different on Linux, I might as well let the user change it to whatever he wants. Plus this also works out well for the user if the user wants to use a custom HUD font and/or a different size, they can use cl_oldscoreboard_width to make it all fit again.

So yeah, positions were changed a bit to accommodate Linux and improve upon the original, but in the end, Linux still has to have a different default width value since the HUD font is obviously bigger there and on 320 the text would overlap with the original values.

Orig:
```c++
// X positions
// relative to the side of the scoreboard
#define NAME_RANGE_MIN  20
#define NAME_RANGE_MAX  145
#define KILLS_RANGE_MIN 130
#define KILLS_RANGE_MAX 170
#define DIVIDER_POS		180
#define DEATHS_RANGE_MIN  185
#define DEATHS_RANGE_MAX  210
#define PING_RANGE_MIN	245
#define PING_RANGE_MAX	295

#define SCOREBOARD_WIDTH 320
```
This implementation:
```c++
	m_WidthScale = m_pCvarOldScoreboardWidth->value / 320.0f;

	int NAME_RANGE_MIN = 20 * m_WidthScale;
	int NAME_RANGE_MAX = 145 * m_WidthScale;
	int KILLS_RANGE_MIN = 130 * m_WidthScale;
	int KILLS_RANGE_MAX = 160 * m_WidthScale;
	int DIVIDER_POS     = 180 * m_WidthScale;
	int DEATHS_RANGE_MIN = 190 * m_WidthScale; // og 185
	int DEATHS_RANGE_MAX = 220 * m_WidthScale;
	// int PING_RANGE_MIN  = 245 * m_WidthScale;
	int PING_RANGE_MAX  = 295 * m_WidthScale;
	int END = 315 * m_WidthScale;

	int xpos_rel = (ScreenWidth - (int)m_pCvarOldScoreboardWidth->value) / 2; // scale the scoreboard based on the cvar
```

# Cvars
* **cl_oldscoreboard 0/1** (defaults to 0, therefore draws the VGUI scoreboard)
* **cl_oldscoreboard_width 320** (defaults to 320 on Windows, basically the original AG 6.6 "value"; defaults to 360 (TODO: OR 380?) on Linux)
* **cl_old_scoreboard_colortags 0/1** (defaults to 0) - disable / enable colortags rendering in nicknames

# Caveats:
* The maximum score/number of deaths that can be rendered without overlapping something else is a 4-digit number (9999) (this can be lower if you set your width really low (on Linux for example) and there's a lot of numbers that are wide (e.g. "0")). I don't see this as a problem since I have yet to see a combined team score higher than 1000 in an actual game (let alone a player score >= 1000). 
* ~~No support for color tags as I couldn't be bothered personally (because of the nickname cutoff code & I already spent way too much time than I anticipated on this) and they weren't in the original either.~~
* Cannot use localization titles.txt for **"#SCORE"** and **"#LATENCY"** since those are drawn using `DrawHudStringRightAligned` which that introduces a bug with localized strings where the X position is off by several pixels randomly (on Linux only, IIRC?) See screenshot below.
* Introduces `gHUD.DrawHudNumberStringFixed` to save some lines of code in `hud_scoreboard.cpp`. I didn't opt for replacing/removing the original DrawHudNumberString function since it could be useful in the future (basically backwards compability, even though it's broken and not used in anything right now -- the only other code which used it is already replaced by #105). I can replace it if you want me to, though.
* No idea what the positioning / sizes look like on macOS. I do have a Hackintosh on an SSD laying around here, but I think that's Catalina without 32-bit so I didn't bother, sorry. Just use the VGUI scoreboard there, I guess.
* More stuff can be read in the code comments

# Miscellaneous / features / info:
* This works rather well out-of-the-box with a custom HUD font (I tried with a monospace - Droid Sans Mono) if the user doesn't change the "tall" (font size) value. If for example the user changes the "tall" value in TrackerScheme.res to a higher value, he can  then use cl_oldscoreboard_width can fix it up so it looks good again. (See screenshots for example)
* Although positions were shifted around as mentioned before, the **basic "layout" is the same** (this includes the part where the scoreboard was never actually centered to the center of the screen), **meaning the X values for the start and end are basically the same just 'scaled' by the cl_oldscoreboard_width, where 320 is the base value.**
* Team line colors in team based modes are the same like in the original - using the team color.
* Player line colors in team based modes are the same like in the original - using the team color.
* Player line colors in non-team based modes are the same like in the original - using the hud_color.
* All the other used colors are conforming to hud_color like in the original.
* More stuff can be read in the code comments

# Screenshots

## Original AG 6.6 (Windows)
### width = 320
![original_ag_66](https://user-images.githubusercontent.com/5108747/119502820-a0fc3b80-bd6a-11eb-9f23-69c1efb3291d.png)

## This implementation
**Ignore the yellow color in lines** even though it's taken in TDM mode, that's just something wrong in my HLDS kreedz gamemode setup that I have for testing (you can see the proper colors in a screenshot below all these that are mostly just to show the positioning)... 

### width = 320
**Windows:**
![win_320](https://user-images.githubusercontent.com/5108747/119502846-a8234980-bd6a-11eb-81da-99f5261cdf3d.png)

**Linux:** (To show why the default isn't 320 on Linux)
![linux_320_why_not](https://user-images.githubusercontent.com/5108747/119504157-00a71680-bd6c-11eb-9520-d654d46ea306.png)


### width = 380
**Windows:**
![win_380](https://user-images.githubusercontent.com/5108747/119502858-abb6d080-bd6a-11eb-9e22-8d13ce138615.png)

**Linux:**
![linux_380](https://user-images.githubusercontent.com/5108747/119502984-c9843580-bd6a-11eb-9abb-b33c8b6e1249.png)

### width = 400
**Windows:**
![win_400](https://user-images.githubusercontent.com/5108747/119502873-afe2ee00-bd6a-11eb-92ff-f89f80976d7e.png)

**Linux:**
![linux_400](https://user-images.githubusercontent.com/5108747/119502971-c7ba7200-bd6a-11eb-8c79-240e59aee925.png)


### width = 480
**Windows:**
![win_480](https://user-images.githubusercontent.com/5108747/119502884-b2454800-bd6a-11eb-8bc7-172b00efe35e.png)

**Linux:**
![linux_480](https://user-images.githubusercontent.com/5108747/119503004-cd17bc80-bd6a-11eb-81be-a3080347e8a4.png)

### width = 560
**Windows:**
![win_560](https://user-images.githubusercontent.com/5108747/119502911-b83b2900-bd6a-11eb-86bc-e721aab85f9e.png)

**Linux:**
![linux_560](https://user-images.githubusercontent.com/5108747/119503021-d143da00-bd6a-11eb-9e8f-1b4a53ec6106.png)


### width = 640
**Windows:**
![win_640](https://user-images.githubusercontent.com/5108747/119502920-bb361980-bd6a-11eb-8fff-c682bfe8a7cf.png)

**Linux:**
![linux_640](https://user-images.githubusercontent.com/5108747/119503030-d30d9d80-bd6a-11eb-8b4c-3d774426d903.png)

## This implementation (actual colors, no broken HLDS TDM like in the ones above)
**Linux:**
![linux_380_colors](https://user-images.githubusercontent.com/5108747/119503327-241d9180-bd6b-11eb-9381-5fd1900c00e4.png)


## This implementation  (Custom HUD font)
(Ignore the yellow color in lines even though it's taken in TDM mode and hud_color is set to red, that's just something wrong in my HLDS kreedz setup I have for testing...)
### Droid Sans Mono (Linux) tall = 20 (original) && cl_oldscoreboard_width = 480 @ 1280x720
![droid_sans_mono_linux_tall_20_480_1080p](https://user-images.githubusercontent.com/5108747/119434975-9b2a3a00-bd19-11eb-8721-c81274a6fc55.png)

### Droid Sans Mono (Linux) tall = 40 (2x times original) && cl_oldscoreboard_width = 1024 @ 1920x1080
![droid_sans_mono_linux_1024_1080p](https://user-images.githubusercontent.com/5108747/119434992-a41b0b80-bd19-11eb-94a7-3c6cb7a9d6cd.png)

--------------

**The localization bug (mentioned above) screenshot**
![bufferedlocalisetextstring_bug](https://user-images.githubusercontent.com/5108747/119435960-8c448700-bd1b-11eb-980d-07ad7165d0f7.png)
