### PR TITLE
Fix viewmodel attachment positions

### DIFF
--- a/cl_dll/StudioModelRenderer.h
+++ b/cl_dll/StudioModelRenderer.h
@@ -50,6 +50,9 @@ public:
 
 	// Find final attachment points
 	virtual void StudioCalcAttachments ( void );
+
+	// Reprojects attachments of the viewmodel if FOV is changed
+	virtual void StudioAdjustViewmodelAttachments(Vector &vOrigin);
 	
 	// Save bone matrices and names
 	virtual void StudioSaveBones( void );

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -78,6 +78,12 @@ qboolean	v_resetCamera = 1;
 
 vec3_t ev_punchangle;
 
+// Used in model rendering code for view model attachment reprojection
+Vector g_vViewOrigin;
+Vector g_vViewForward;
+Vector g_vViewRight;
+Vector g_vViewUp;
+
 cvar_t	*scr_ofsx;
 cvar_t	*scr_ofsy;
 cvar_t	*scr_ofsz;
@@ -1703,6 +1709,12 @@ void CL_DLLEXPORT V_CalcRefdef( struct ref_params_s *pparams )
 	{
 		V_CalcNormalRefdef ( pparams );
 	}
+
+	// Save view data for viewmodel renderer
+	g_vViewOrigin = pparams->vieworg;
+	g_vViewForward = pparams->forward;
+	g_vViewRight = pparams->right;
+	g_vViewUp = pparams->up;
 
 /*
 // Example of how to overlay the whole screen with red at 50 % alpha


### PR DESCRIPTION
Fixes incorrect weapon effect positions (sprites and beams) when viewmodel FOV is different from default. It uses code from Source SDK (c_baseviewmodel.cpp, ::FormatViewModelAttachment) to reproject on-screen position from main view FOV to viewmodel FOV.

I used global variables to save view position and direction vectors since they are not available outside of `V_CalcRefDef`.

Demo:
https://www.youtube.com/watch?v=9_10Oms73Fg