### PR TITLE
Implement command customtimer

### DIFF
--- a/cl_dll/CMakeLists.txt
+++ b/cl_dll/CMakeLists.txt
@@ -44,6 +44,8 @@ add_sources(
 	hud_crosshairs.h
 	hud_ctf.cpp
 	hud_ctf.h
+	hud_customtimer.cpp
+	hud_customtimer.h
 	hud_debug.cpp
 	hud_debug.h
 	hud_location.cpp

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -562,6 +562,7 @@ void CHud :: Init( void )
 	m_Countdown.Init();
 	m_Crosshairs.Init();
 	m_CTF.Init();
+	m_CustomTimer.Init();
 	m_Debug.Init();
 	m_Location.Init();
 	m_NextMap.Init();
@@ -726,6 +727,7 @@ void CHud :: VidInit( void )
 	m_Countdown.VidInit();
 	m_Crosshairs.VidInit();
 	m_CTF.VidInit();
+	m_CustomTimer.VidInit();
 	m_Debug.VidInit();
 	m_Location.VidInit();
 	m_NextMap.VidInit();

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -94,6 +94,7 @@ struct HUDLIST {
 
 #include "hud_countdown.h"
 #include "hud_crosshairs.h"
+#include "hud_customtimer.h"
 #include "hud_ctf.h"
 #include "hud_debug.h"
 #include "hud_location.h"
@@ -671,6 +672,7 @@ public:
 	CHudCountdown	m_Countdown;
 	CHudCrosshairs	m_Crosshairs;
 	CHudCTF			m_CTF;
+	CHudCustomTimer m_CustomTimer;
 	CHudDebug		m_Debug;
 	CHudLocation	m_Location;
 	CHudNextMap		m_NextMap;

--- a/cl_dll/hud_customtimer.cpp
+++ b/cl_dll/hud_customtimer.cpp
@@ -1,0 +1,61 @@
+#include "hud.h"
+#include "cl_util.h"
+
+DECLARE_COMMAND(m_CustomTimer, CustomTimer);
+
+int CHudCustomTimer::Init()
+{
+	HOOK_COMMAND("customtimer", CustomTimer);
+
+	m_iFlags = 0;
+
+	gHUD.AddHudElem(this);
+	return 0;
+}
+
+int CHudCustomTimer::VidInit()
+{
+	m_iFlags &= ~HUD_ACTIVE;
+	return 1;
+}
+
+int CHudCustomTimer::Draw(float time)
+{
+	if (gHUD.m_flTime >= m_flTurnoffTime || gHUD.m_iIntermission)
+	{
+		m_iFlags &= ~HUD_ACTIVE;
+		gEngfuncs.pfnPlaySoundByName("fvox/bell.wav", 1.0f);
+		return 0;
+	}
+
+	char str[64];
+	int r, g, b;
+	auto diff = m_flTurnoffTime - gHUD.m_flTime;
+	UnpackRGB(r, g, b, gHUD.m_iDefaultHUDColor);
+
+	FillRGBA((ScreenWidth / 2) - 50, (gHUD.m_scrinfo.iCharHeight * 4) - 6, (diff / m_flSeconds) * 100, 4, r, g, b, 210);
+	snprintf(str, sizeof(str), "Timer: %d", (int)diff);
+	gHUD.DrawHudStringCentered(ScreenWidth / 2, gHUD.m_scrinfo.iCharHeight * 4, str, r, g, b);
+
+	return 0;
+}
+
+int CHudCustomTimer::UserCmd_CustomTimer()
+{
+	if (gEngfuncs.Cmd_Argc() == 2)
+	{
+		auto time = atof(gEngfuncs.Cmd_Argv(1));
+		if (time > 172800)
+		{
+			gEngfuncs.Con_Printf("Time can't be higher than 172800 seconds (2 days).\n");
+			return 1;
+		}
+		m_flSeconds = time;
+		m_flTurnoffTime = gHUD.m_flTime + time;
+		m_iFlags |= HUD_ACTIVE;
+	}
+	else
+		gEngfuncs.Con_Printf("customtimer <seconds> - start a local countdown timer\n");
+
+	return 1;
+}

--- a/cl_dll/hud_customtimer.h
+++ b/cl_dll/hud_customtimer.h
@@ -1,0 +1,20 @@
+#ifndef CUSTOMTIMER_H
+#define CUSTOMTIMER_H
+
+#pragma once
+#include <cstdint>
+
+class CHudCustomTimer : public CHudBase
+{
+	float m_flSeconds;
+	float m_flTurnoffTime;
+
+public:
+	virtual int Init();
+	virtual int VidInit();
+	virtual int Draw(float time);
+
+	int UserCmd_CustomTimer();
+};
+
+#endif //CUSTOMTIMER_H


### PR DESCRIPTION
Closes #64. Implemented mostly 1:1 to the the AG 6.6 implementation. I added a bar (and a colon in the text), because I think it looks OK, but this is of course up for discussion, for example if @chortex who originally reported this issue is still around, or any other players that use customtimer in their binds.

I've also decided for showing "Timer: 0" when the time is <1.0 (and 9 when "customtimer 10" starts and number instantly becomes 9.999999) like the original implementation does instead of subtracting and adding 1.

**AG 6.6:**
![image](https://user-images.githubusercontent.com/5108747/119065549-191ad800-b9de-11eb-8b33-82c731ff58c9.png)

**OpenAG:**
**GIF:** 
![lal](https://user-images.githubusercontent.com/5108747/119066543-4b2d3980-b9e0-11eb-9967-3118b53b5ec9.gif)
**Video:** 
https://user-images.githubusercontent.com/5108747/119066552-4e282a00-b9e0-11eb-9db7-8e586347dac9.mp4

(The sound like in the original is present I just didn't record it.)

I've also added a check to fail if the time in seconds is greater than 2 days since in the original implementation you could overflow. I've opted for 2 days as that's the maximum `mp_timelimit` (IIRC) so there shouldn't be a need for a higher value.
