### PR TITLE
Add AppVeyor CI for macOS

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,38 @@
+version: '{build}-{branch}'
+
+skip_commits:
+  files:
+    - '*.bat'
+    - '*.md'
+    - '.github/**'
+    - '.travis.yml'
+    - 'LICENSE*'
+
+skip_branch_with_pr: true
+
+image: macos-mojave
+
+clone_depth: 1
+
+environment:
+  DEVELOPER_DIR: /Applications/Xcode-9.4.1.app/Contents/Developer
+
+configuration: [Release, Debug]
+
+before_build:
+  - |
+    git submodule update --init --recursive --depth 1 -j $(sysctl -n hw.activecpu)
+    cmake -DCMAKE_BUILD_TYPE=$CONFIGURATION -B build
+
+build_script:
+  - |
+    cd build
+    make
+
+test: off
+
+on_success:
+  - |
+    if [[ "$CONFIGURATION" = "Release" ]]; then
+      appveyor PushArtifact client.dylib
+    fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -100,28 +100,3 @@ jobs:
     - name: Build
       working-directory: build
       run: ninja
-
-# GitHub Actions doesn't have a needed macOS/Xcode version
-  #build-macos:
-  #  runs-on: macos
-  #  strategy:
-  #    fail-fast: false
-  #    matrix:
-  #      configuration: [Release, Debug]
-  #  steps:
-  #  - uses: actions/checkout@v2
-  #    with:
-  #      submodules: recursive
-  #  - name: Prepare for build
-  #    env:
-  #      HOMEBREW_NO_ANALYTICS: 1
-  #    run: |
-  #      brew analytics off
-  #      brew update
-  #      brew install ninja
-  #      mkdir build
-  #      cd build
-  #      cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} ..
-  #  - name: Build
-  #    working-directory: build
-  #    run: ninja


### PR DESCRIPTION
Travis is no longer free*, so another CI like Azure Pipelines or AppVeyor should be added.

GitHub Actions isn't an option for macOS since it doesn't have Xcode 9.4.1. (https://github.com/actions/virtual-environments/issues/2347)

AppVeyor:
  * Can easily link to newest build.

Azure Pipelines:
  * Faster. (allows more than one build simultaneously)