### PR TITLE
HLTV: use the client's default_fov value, not 90

### DIFF
--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -84,11 +84,12 @@ void CHud::Think(void)
 	{  // only let players adjust up in fov,  and only if they are not overriden by something else
 		m_iFOV = max( default_fov->value, 90 );  
 	}
-	
-	if ( gEngfuncs.IsSpectateOnly() )
+
+	// Don't change the FOV for HLTV to a constant, use the updated value like when in a normal game
+	/*if ( gEngfuncs.IsSpectateOnly() )
 	{
-		m_iFOV = gHUD.m_Spectator.GetFOV();	// default_fov->value;
-	}
+		m_iFOV = gHUD.m_Spectator.GetFOV();
+	}*/
 
 	Bench_CheckStart();
 }

--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -173,7 +173,7 @@ int CHudSpectator::Init()
 	m_flNextObserverInput = 0.0f;
 	m_zoomDelta	= 0.0f;
 	m_moveDelta = 0.0f;
-	m_FOV = 90.0f;
+	m_FOV = gHUD.m_iFOV;
 	m_chatEnabled = (gHUD.m_SayText.m_HUD_saytext->value!=0);
 	iJumpSpectator	= 0;
 
@@ -2023,7 +2023,7 @@ void CHudSpectator::Reset()
 
 	memset( &m_OverviewEntities, 0, sizeof(m_OverviewEntities));
 
-	m_FOV = 90.0f;
+	m_FOV = gHUD.m_iFOV;
 
 	m_IsInterpolating = false;
 


### PR DESCRIPTION
default_fov's value like when playing the game is now used for when the client is only watching a game through a HLTV proxy.

**hud_redraw.cpp:**
* The changes here are for when default_fov is changed while watching
* Commented the hud_redraw.cpp code instead of deleting just so we know that it was there before. 
* * Therefore it just uses the FOV logic in the code above and skips setting it to a constant for HLTV like it originally does.

**hud_spectator.cpp**
* The changes here are used when you connect to a proxy from the game menu before joining any other game after you launch OpenAG.

A thing that probably never bugged anyone, but it sure bugs me. 


