### PR TITLE
Use the target player's weapon crosshair when spectating in first person, don't replace it

### DIFF
--- a/cl_dll/hud_spectator.cpp
+++ b/cl_dll/hud_spectator.cpp
@@ -1948,16 +1948,28 @@ void CHudSpectator::CheckSettings()
 	}
 
 	// HL/TFC has no oberserver corsshair, so set it client side
-	if ( (g_iUser1 == OBS_IN_EYE) || (g_iUser1 == OBS_ROAMING) ) 
+	// Soup: For first person, leave the crosshair alone
+	// The game gives it to us elsewhere, so don't replace it here
+	// Commenting out instead of deletion for posterity
+	if ( g_iUser1 == OBS_IN_EYE )
+	{
+		/* m_crosshairRect.left	 = 24;
+		m_crosshairRect.top	 = 0;
+		m_crosshairRect.right	 = 48;
+		m_crosshairRect.bottom = 24;
+
+		SetCrosshair( m_hCrosshair, m_crosshairRect, 255, 255, 255 ); */
+	}
+	else if ( g_iUser1 == OBS_ROAMING ) // set the 9mm handgun crosshair for Free look
 	{
 		m_crosshairRect.left	 = 24;
 		m_crosshairRect.top	 = 0;
 		m_crosshairRect.right	 = 48;
 		m_crosshairRect.bottom = 24;
-					
+
 		SetCrosshair( m_hCrosshair, m_crosshairRect, 255, 255, 255 );
 	}
-	else
+	else // other observer modes don't have a crosshair
 	{
 		memset( &m_crosshairRect,0,sizeof(m_crosshairRect) );
 		SetCrosshair( 0, m_crosshairRect, 0, 0, 0 );


### PR DESCRIPTION
As per Alex's bug report:
> There is just 1 more thing that makes ag6.6 different: you can see your default handgun crosschair @ spectate mode in OpenAG. A lot of peeps use the command r_drawviewmodel 0 so there is no way to understand what the weapon in hand atm. 

