### PR TITLE
Rainbow HUD: Fix invisible text being visible

### DIFF
--- a/cl_dll/rainbow.cpp
+++ b/cl_dll/rainbow.cpp
@@ -96,7 +96,15 @@ void CRainbow::SPR_DrawAdditiveRainbow(int frame, int x, int y, const rect_s *pr
 
 int CRainbow::DrawString(int x, int y, const char *str, int r, int g, int b)
 {
-    return DrawRainbowString(x, y, str, gHUD.m_Rainbow.m_pfnDrawString);
+    if (r == 0 && g == 0 && b == 0)
+    {
+        // Draw invisible text without rainbow color
+        return gHUD.m_Rainbow.m_pfnDrawString(x, y, str, r, g, b);
+    }
+    else
+    {
+        return DrawRainbowString(x, y, str, gHUD.m_Rainbow.m_pfnDrawString);
+    }
 }
 
 int CRainbow::DrawStringReverse(int x, int y, const char *str, int r, int g, int b)

--- a/cl_dll/rainbow.cpp
+++ b/cl_dll/rainbow.cpp
@@ -109,8 +109,8 @@ int CRainbow::DrawString(int x, int y, const char *str, int r, int g, int b)
 
 int CRainbow::DrawStringReverse(int x, int y, const char *str, int r, int g, int b)
 {
-    // Calc string width by drawing outside the screen
-    int width = gEngfuncs.pfnDrawString(ScreenWidth + 1, y, str, r, g, b);
+    // Get string width
+    int width = gHUD.GetHudStringWidth(str);
 
     // Draw it shifted to the left by width pixels
     return x + DrawString(x - width, y, str, r, g, b);


### PR DESCRIPTION
```cpp
int CHud::GetHudStringWidth(const char* string)
{
	return gEngfuncs.pfnDrawString(0, 0, string, 0, 0, 0);
}
```

`GetHudStringWidth` gets the string length by drawing it with a black color (due to additive blending mode, it becomes transparent). Rainbow HUD overrides this color, causing the text to become visible.

This PR also fixes a small issue in `DrawStringReverse`. It used to call `DrawString` to get the string width. `DrawString` needs to decode the input string into separate UTF-8 chars to draw them with different colors but it isn't needed in this case. I replaced it with a call to `CHud::GetHudStringWidth`.