### PR TITLE
Skip NULL nicknames in the sorted scoreboard in order to get rid of ghost players when they disconnect while +showscores is held

### DIFF
--- a/cl_dll/hud_oldscoreboard.cpp
+++ b/cl_dll/hud_oldscoreboard.cpp
@@ -217,6 +217,9 @@ int CHudOldScoreboard::Draw(float fTime)
 			hud_player_info_t* pl_info = &g_PlayerInfoList[sorted];
 			extra_player_info_t* pl_info_extra = &g_PlayerExtraInfo[sorted];
 
+			if (pl_info->name == NULL)
+				continue;
+
 			ypos = ROW_TOP + ROW_RANGE_MIN + (list_slot * ROW_GAP);
 
 			// check we haven't drawn too far down

--- a/cl_dll/hud_oldscoreboard.cpp
+++ b/cl_dll/hud_oldscoreboard.cpp
@@ -218,7 +218,10 @@ int CHudOldScoreboard::Draw(float fTime)
 			extra_player_info_t* pl_info_extra = &g_PlayerExtraInfo[sorted];
 
 			if (pl_info->name == NULL)
+			{
+				gViewPort->m_pScoreBoard->RebuildTeams();
 				continue;
+			}
 
 			ypos = ROW_TOP + ROW_RANGE_MIN + (list_slot * ROW_GAP);
 


### PR DESCRIPTION
Fixes #119 (that's present on some servers), hopefully. ;-)


**EDIT: Tested by me & @iCHOPPERi on Ironanjuu & `AGHLDM DE #2 | 1000 FPS | FastDL`, seems like this does the trick.** :)

