### PR TITLE
Added black color for messages

### DIFF
--- a/cl_dll/color_tags.cpp
+++ b/cl_dll/color_tags.cpp
@@ -14,7 +14,8 @@ namespace color_tags {
 			{ 0,   255, 255 },
 			{ 255, 0,   255 },
 			{ 136, 136, 136 },
-			{ 255, 255, 255 }
+			{ 255, 255, 255 },
+			{ 0,   0,   0 }
 		};
 	}
 
@@ -77,7 +78,7 @@ namespace color_tags {
 				string = temp + 2;
 				temp = temp + 2;
 
-				if (color_index == '0' || color_index == '9') {
+				if (color_index == '0') {
 					custom_color = false;
 				} else {
 					custom_color = true;

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -466,6 +466,9 @@ int CHud::DrawHudStringWithColorTags(int x, int y, char* string, int default_r, 
 			b = default_b;
 		}
 
+		if ((r + g + b) == 0)
+			r = g = b = 90;
+
 		x += gEngfuncs.pfnDrawString(x, y, string, r, g, b);
 	});
 


### PR DESCRIPTION
Added black color for messages and nicknames that can be used via ^9 tag.
Regarding the #98 issue.