### PR TITLE
Added cl_viewmodel_disable_idle to disable idle/fidget animations on the viewmodel models

### DIFF
--- a/cl_dll/StudioModelRenderer.h
+++ b/cl_dll/StudioModelRenderer.h
@@ -132,6 +132,10 @@ public:
 	cvar_t			*m_pCvarDrawEntities;
 	// Change viewmodel FOV
 	cvar_t			*m_pCvarViewmodelFov;
+	// Disable viewmodel idle/fidget animations on viewmodels
+	cvar_t			*m_pCvarViewmodelNoIdle;
+	// Disable viewmodel draw/holster/deploy animations on viewmodels
+	cvar_t			*m_pCvarViewmodelNoEquip;
 	// The entity which we are currently rendering.
 	cl_entity_t		*m_pCurrentEntity;		
 


### PR DESCRIPTION
Hello.

I've seen a lot of people use the edited so-called "HLTV" models where `idle` and `fidget` sequences are set to 1 frame and 1 fps, this does the same thing but without replacing the original (or HD) models. This works on all the default weapons, but probably not on custom added 3rd party server side weapons (not models, i.e. weapons that are not in original HL1), though, unless they use `*fidget*` and `*idle*` in their sequence labels. 

It also doesn't work on any custom weapon models that use different labels for idle / fidget. <- If you think it'd be beneficial if this worked for all custom models including ones that have different labels, I can go ahead and implement it based on indexes of sequences for each gun instead.

**EDIT**: I've had a discussion with @execut4ble and we figured that "HLTV" means more like "1.6" HLTV behaviour (or HLTV viewmodels by Vryndar etc.), where even equip animation for example isn't there, therefore I've changed the cvar accordingly to just imply "no idle or fidget animations", we've figured that equip is a useful animation since you know when you can actually shoot the gun. 

So either just leave the renamed cvar like this to **disable idle/fidget** (`cl_viewmodel_disable_idle`) or we could add a feature where the cvar would be `cl_viewmodel_hltv` (or something else, see below), but it would have levels of 
* **1*** = no idle animations, no fidget animations  
* **2*** = no equip/holster/draw animations

It could also just be two seperate cvars `cl_viewmodel_disable_idle` and `cl_viewmodel_disable_equip` for example (**<- this is the current PR implementation**). Or again, two in one `[11:44 PM] execut4ble: or cl_viewmodel_static (0/1/2)` etc. etc.

For completeness:
* The behaviour for **1*** https://play.sourceruns.org/files/Fixed%20v_models.zip - where only `idle` and `fidget` animations are disabled. 

* The behaviour for **2*** is based on https://play.sourceruns.org/files/HLTV_viewmodels_by_Vryndar.zip (which also stops draw/holster/equip/whatever you wanna call it as opposed to Fixed v_models.zip) - <-- This behaviour (where there's also no equip) can be seen in this video: https://youtu.be/Fd1K9l_Agsw (I wouldn't personally add stuff like the "no gauss spin" to the "2" mode, but I dunno.)

**EDIT 2:** I've added the no equip (holster/draw/deploy) cvar `cl_viewmodel_disable_equip`, like mentioned above, for posterity. Can be later changed to be a single one / removed entirely, etc. like mentioned above

**EDIT 3: Behaviour of these two cvars can be see in this video:**
https://user-images.githubusercontent.com/5108747/121267183-16642200-c8bc-11eb-9171-36c8945b7c8c.mp4

