### PR TITLE
Sync up the condition for cl_righthand with the one that's in engine

### DIFF
--- a/cl_dll/StudioModelRenderer.cpp
+++ b/cl_dll/StudioModelRenderer.cpp
@@ -983,7 +983,7 @@ void CStudioModelRenderer::StudioSetupBones ( void )
 			extern cvar_t* cl_righthand;
 			if (m_pCurrentEntity == gEngfuncs.GetViewModel()
 				&& IEngineStudio.IsHardware()
-				&& cl_righthand->value != 0.0f)
+				&& cl_righthand->value > 0.0f)
 			{
 				for (size_t j = 0; j < 4; ++j)
 					bonematrix[1][j] *= -1.0;

--- a/cl_dll/ev_common.cpp
+++ b/cl_dll/ev_common.cpp
@@ -175,7 +175,7 @@ void EV_GetDefaultShellInfo( event_args_t *args, float *origin, float *velocity,
 	}
 
 	extern cvar_t* cl_righthand;
-	fR = (cl_righthand->value != 0 ? -1 : 1) * gEngfuncs.pfnRandomFloat( 50, 70 );
+	fR = (cl_righthand->value > 0.0f ? -1 : 1) * gEngfuncs.pfnRandomFloat( 50, 70 );
 	fU = gEngfuncs.pfnRandomFloat( 100, 150 );
 
 	for ( i = 0; i < 3; i++ )

--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -479,7 +479,7 @@ void EV_FireGlock1( event_args_t *args )
 		V_PunchAxis( 0, -2.0 );
 	}
 
-	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, (cl_righthand->value != 0.0f ? -1 : 1) * 4 );
+	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 4 );
 
 	EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHELL ); 
 
@@ -524,7 +524,7 @@ void EV_FireGlock2( event_args_t *args )
 		V_PunchAxis( 0, -2.0 );
 	}
 
-	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, (cl_righthand->value != 0.0f ? -1 : 1) * 4 );
+	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 4 );
 
 	EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHELL ); 
 
@@ -579,7 +579,7 @@ void EV_FireShotGunDouble( event_args_t *args )
 
 	for ( j = 0; j < 2; j++ )
 	{
-		EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 32, -12, (cl_righthand->value != 0.0f ? -1 : 1) * 6 );
+		EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 32, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 6 );
 
 		EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHOTSHELL ); 
 	}
@@ -632,7 +632,7 @@ void EV_FireShotGunSingle( event_args_t *args )
 		V_PunchAxis( 0, -5.0 );
 	}
 
-	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 32, -12, (cl_righthand->value != 0.0f ? -1 : 1) * 6 );
+	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 32, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 6 );
 
 	EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHOTSHELL ); 
 
@@ -689,7 +689,7 @@ void EV_FireMP5( event_args_t *args )
 		V_PunchAxis( 0, gEngfuncs.pfnRandomFloat( -2, 2 ) );
 	}
 
-	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, (cl_righthand->value != 0.0f ? -1 : 1) * 4 );
+	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 4 );
 
 	EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHELL ); 
 

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -669,7 +669,7 @@ void V_CalcNormalRefdef ( struct ref_params_s *pparams )
 	// This does not change the angles of the viewmodel camera
 	// This does not the player's angles & origin
 	extern cvar_t* cl_righthand;
-	if (cl_righthand->value != 0.0)
+	if (cl_righthand->value > 0.0f)
 	{
 		right_offset *= -1;
 	}


### PR DESCRIPTION
Resolves #128 

Looks like an engine bug (couldn't really find where it happens in Ghidra, but it's pretty obvious seeing as we don't use cl_righthand's *actual* value anywhere in the client code), so not much we can do here other than clamp it.

* ~~Not just using min max (without if statement) since this way it will only be called once.~~
* ~~Resetting the cvar using Cvar_SetValue instead of min maxing the value, because engine is at fault and uses the cvar's value.~~


EDIT: alright yea looks like this is it

```c++
  (*qglCullFace)(0x404);
  bVar4 = false;
  if (((cl_righthand != (cvar_t *)0x0) && (0.0 < cl_righthand->value)) &&
     (cl.viewent.index == currententity->index)) {
    (*qglDisable)(0xb44);
    bVar4 = true;
  }
```