### PR TITLE
Rainbow HUD: Fix negative phase

### DIFF
--- a/cl_dll/rainbow.cpp
+++ b/cl_dll/rainbow.cpp
@@ -50,6 +50,8 @@ void CRainbow::GetRainbowColor(int x, int y, int &r, int &g, int &b)
     phase += m_pCvarRainbowXPhase->value * x;
     phase += m_pCvarRainbowYPhase->value * y;
     phase = fmod(phase, 360);
+    if (phase < 0)
+        phase += 360;
 
     HSVtoRGB(phase, m_flSat, m_flVal, r, g, b);
 }


### PR DESCRIPTION
If the game has just started (`gHUD.m_flTime` is low) and x or y are negative, current phase angle in `GetRainbowColor` can become negative. Then `fmod 360`, which returns values in the range (-360; 360), can return a negative number and trigger the assetion in `HSVtoRGB`.

This PR resolves that by adding 360 degrees to fmod result if it's negative.