### PR TITLE
Add jumpspeed HUD like in BXT

### DIFF
--- a/cl_dll/CMakeLists.txt
+++ b/cl_dll/CMakeLists.txt
@@ -48,6 +48,8 @@ add_sources(
 	hud_customtimer.h
 	hud_debug.cpp
 	hud_debug.h
+	hud_jumpspeed.cpp
+	hud_jumpspeed.h
 	hud_location.cpp
 	hud_location.h
 	hud_msg.cpp

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -565,6 +565,7 @@ void CHud :: Init( void )
 	m_Crosshairs.Init();
 	m_CTF.Init();
 	m_CustomTimer.Init();
+	m_Jumpspeed.Init();
 	m_Debug.Init();
 	m_Location.Init();
 	m_NextMap.Init();
@@ -732,6 +733,7 @@ void CHud :: VidInit( void )
 	m_CTF.VidInit();
 	m_CustomTimer.VidInit();
 	m_Debug.VidInit();
+	m_Jumpspeed.VidInit();
 	m_Location.VidInit();
 	m_NextMap.VidInit();
 	m_PlayerId.VidInit();

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -97,6 +97,7 @@ struct HUDLIST {
 #include "hud_customtimer.h"
 #include "hud_ctf.h"
 #include "hud_debug.h"
+#include "hud_jumpspeed.h"
 #include "hud_location.h"
 #include "hud_nextmap.h"
 #include "hud_oldscoreboard.h"
@@ -682,6 +683,7 @@ public:
 	CHudScores	m_Scores;
 	CHudSettings	m_Settings;
 	CHudSpeedometer	m_Speedometer;
+	CHudJumpspeed   m_Jumpspeed;
 	CHudSuddenDeath		m_SuddenDeath;
 	CHudTimeout		m_Timeout;
 	CHudTimer		m_Timer;

--- a/cl_dll/hud_jumpspeed.cpp
+++ b/cl_dll/hud_jumpspeed.cpp
@@ -13,7 +13,6 @@ int CHudJumpspeed::Init()
 	m_iFlags = HUD_ACTIVE;
 
 	hud_jumpspeed = CVAR_CREATE("hud_jumpspeed", "0", FCVAR_ARCHIVE);
-	hud_jumpspeed_below_cross = CVAR_CREATE("hud_jumpspeed_below_cross", "0", FCVAR_ARCHIVE);
 
 	gHUD.AddHudElem(this);
 	return 0;
@@ -34,12 +33,10 @@ int CHudJumpspeed::Draw(float flTime)
 	UnpackRGB(r, g, b, gHUD.m_iDefaultHUDColor);
 
 	int y;
-	if (hud_jumpspeed_below_cross->value != 0)
+	if (CVAR_GET_FLOAT("hud_speedometer_below_cross") != 0.0f)
 		y = ScreenHeight / 2 + gHUD.m_iFontHeight / 2 + gHUD.m_iFontHeight;
 	else
 		y = ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2 - gHUD.m_iFontHeight;
-
-	static float lastTime = flTime;
 
 	// Can be negative if we went back in time (for example, loaded a save).
 	double timeDelta = std::fmax(flTime - lastTime, 0.0f);
@@ -50,8 +47,8 @@ int CHudJumpspeed::Draw(float flTime)
 		passedTime = FADE_DURATION_JUMPSPEED;
 
 	float colorVel[3] = { r - fadingFrom[0] / FADE_DURATION_JUMPSPEED,
-	g - fadingFrom[1] / FADE_DURATION_JUMPSPEED,
-	b - fadingFrom[2] / FADE_DURATION_JUMPSPEED };
+	                      g - fadingFrom[1] / FADE_DURATION_JUMPSPEED,
+	                      b - fadingFrom[2] / FADE_DURATION_JUMPSPEED };
 
 	r = static_cast<int>(r - colorVel[0] * (FADE_DURATION_JUMPSPEED - passedTime));
 	g = static_cast<int>(g - colorVel[1] * (FADE_DURATION_JUMPSPEED - passedTime));
@@ -65,8 +62,6 @@ int CHudJumpspeed::Draw(float flTime)
 
 void CHudJumpspeed::UpdateSpeed(const float velocity[3])
 {
-	static float prevVel[3] = { 0.0f, 0.0f, 0.0f };
-
 	if (FADE_DURATION_JUMPSPEED > 0.0f)
 	{
 		if ((velocity[2] != 0.0f && prevVel[2] == 0.0f)

--- a/cl_dll/hud_jumpspeed.cpp
+++ b/cl_dll/hud_jumpspeed.cpp
@@ -1,0 +1,97 @@
+#include <cmath>
+#include <cstring>
+
+#include "hud.h"
+#include "cl_util.h"
+#include "parsemsg.h"
+#include "hudgl.h"
+
+#define FADE_DURATION_JUMPSPEED 0.7f
+
+int CHudJumpspeed::Init()
+{
+	m_iFlags = HUD_ACTIVE;
+
+	hud_jumpspeed = CVAR_CREATE("hud_jumpspeed", "0", FCVAR_ARCHIVE);
+	hud_jumpspeed_below_cross = CVAR_CREATE("hud_jumpspeed_below_cross", "0", FCVAR_ARCHIVE);
+
+	gHUD.AddHudElem(this);
+	return 0;
+}
+
+int CHudJumpspeed::VidInit()
+{
+	passedTime = FADE_DURATION_JUMPSPEED;
+	return 1;
+}
+
+int CHudJumpspeed::Draw(float flTime)
+{
+	if (hud_jumpspeed->value == 0.0f)
+		return 0;
+
+	int r, g, b;
+	UnpackRGB(r, g, b, gHUD.m_iDefaultHUDColor);
+
+	int y;
+	if (hud_jumpspeed_below_cross->value != 0)
+		y = ScreenHeight / 2 + gHUD.m_iFontHeight / 2 + gHUD.m_iFontHeight;
+	else
+		y = ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2 - gHUD.m_iFontHeight;
+
+	static float lastTime = flTime;
+
+	// Can be negative if we went back in time (for example, loaded a save).
+	double timeDelta = std::fmax(flTime - lastTime, 0.0f);
+	passedTime += timeDelta;
+
+	// Check for Inf, NaN, etc.
+	if (passedTime > FADE_DURATION_JUMPSPEED || !std::isnormal(passedTime))
+		passedTime = FADE_DURATION_JUMPSPEED;
+
+	float colorVel[3] = { r - fadingFrom[0] / FADE_DURATION_JUMPSPEED,
+	g - fadingFrom[1] / FADE_DURATION_JUMPSPEED,
+	b - fadingFrom[2] / FADE_DURATION_JUMPSPEED };
+
+	r = static_cast<int>(r - colorVel[0] * (FADE_DURATION_JUMPSPEED - passedTime));
+	g = static_cast<int>(g - colorVel[1] * (FADE_DURATION_JUMPSPEED - passedTime));
+	b = static_cast<int>(b - colorVel[2] * (FADE_DURATION_JUMPSPEED - passedTime));
+
+	lastTime = flTime;
+	gHUD.DrawHudNumberCentered(ScreenWidth / 2, y, speed, r, g, b);
+
+	return 0;
+}
+
+void CHudJumpspeed::UpdateSpeed(const float velocity[3])
+{
+	static float prevVel[3] = { 0.0f, 0.0f, 0.0f };
+
+	if (FADE_DURATION_JUMPSPEED > 0.0f)
+	{
+		if ((velocity[2] != 0.0f && prevVel[2] == 0.0f)
+			|| (velocity[2] > 0.0f && prevVel[2] < 0.0f))
+		{
+			double difference = std::hypot(velocity[0], velocity[1]) - speed;
+			if (difference != 0.0f)
+			{
+				if (difference > 0.0f)
+				{
+					fadingFrom[0] = 0;
+					fadingFrom[1] = 255;
+					fadingFrom[2] = 0;
+				}
+				else
+				{
+					fadingFrom[0] = 255;
+					fadingFrom[1] = 0;
+					fadingFrom[2] = 0;
+				}
+
+				passedTime = 0.0;
+				speed = std::hypot(velocity[0], velocity[1]);
+			}
+		}
+	}
+	VectorCopy(velocity, prevVel);
+}

--- a/cl_dll/hud_jumpspeed.cpp
+++ b/cl_dll/hud_jumpspeed.cpp
@@ -13,6 +13,7 @@ int CHudJumpspeed::Init()
 	m_iFlags = HUD_ACTIVE;
 
 	hud_jumpspeed = CVAR_CREATE("hud_jumpspeed", "0", FCVAR_ARCHIVE);
+	hud_jumpspeed_below_cross = CVAR_CREATE("hud_jumpspeed_below_cross", "0", FCVAR_ARCHIVE);
 
 	gHUD.AddHudElem(this);
 	return 0;
@@ -33,7 +34,7 @@ int CHudJumpspeed::Draw(float flTime)
 	UnpackRGB(r, g, b, gHUD.m_iDefaultHUDColor);
 
 	int y;
-	if (CVAR_GET_FLOAT("hud_speedometer_below_cross") != 0.0f)
+	if (hud_jumpspeed_below_cross->value != 0.0f)
 		y = ScreenHeight / 2 + gHUD.m_iFontHeight / 2 + gHUD.m_iFontHeight;
 	else
 		y = ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2 - gHUD.m_iFontHeight;

--- a/cl_dll/hud_jumpspeed.h
+++ b/cl_dll/hud_jumpspeed.h
@@ -9,6 +9,8 @@ class CHudJumpspeed : public CHudBase
 	cvar_t* hud_jumpspeed_below_cross;
 
 	int fadingFrom[3];
+	float prevVel[3] = { 0.0f, 0.0f, 0.0f };
+	float lastTime;
 	double passedTime;
 
 public:

--- a/cl_dll/hud_jumpspeed.h
+++ b/cl_dll/hud_jumpspeed.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <cstdint>
+
+class CHudJumpspeed : public CHudBase
+{
+	uint16_t speed;
+
+	cvar_t* hud_jumpspeed;
+	cvar_t* hud_jumpspeed_below_cross;
+
+	int fadingFrom[3];
+	double passedTime;
+
+public:
+	virtual int Init();
+	virtual int VidInit();
+	virtual int Draw(float time);
+
+	void UpdateSpeed(const float velocity[3]);
+};

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -1699,6 +1699,7 @@ void CL_DLLEXPORT V_CalcRefdef( struct ref_params_s *pparams )
 //	RecClCalcRefdef(pparams);
 
 	gHUD.m_Speedometer.UpdateSpeed(pparams->simvel);
+	gHUD.m_Jumpspeed.UpdateSpeed(pparams->simvel);
 
 	// intermission / finale rendering
 	if ( pparams->intermission )


### PR DESCRIPTION
Closes #133

Stolen from BXT, based on hud_speedometer.cpp. 

Normal Y pos based on the original BXT (1 "px" above hud_speedometer), for "below cross" I've decided to have it under hud_speedometer for simplicity (i.e. not dynamically moving based on `hud_speedometer_below_cross`'s value)

Not too sure about the `static float`s and what not in the code, so do tell me, if it somehow doesn't make sense here, but does in BXT.

**Video:** 
https://user-images.githubusercontent.com/5108747/123566130-3900a100-d7bf-11eb-88d1-b09b33f0f514.mp4



