### PR TITLE
Viewmodel ejected shells fixes

### DIFF
--- a/cl_dll/GameStudioModelRenderer.h
+++ b/cl_dll/GameStudioModelRenderer.h
@@ -10,6 +10,10 @@
 #if defined( _WIN32 )
 #pragma once
 #endif
+#include "com_model.h"
+#include "studio.h"
+#include "r_studioint.h"
+#include "StudioModelRenderer.h"
 
 /*
 ====================

--- a/cl_dll/StudioModelRenderer.cpp
+++ b/cl_dll/StudioModelRenderer.cpp
@@ -2019,16 +2019,20 @@ void CStudioModelRenderer::StudioCalcAttachments( void )
 	{
 		VectorTransform( pattachment[i].org, (*m_plighttransform)[pattachment[i].bone],  m_pCurrentEntity->attachment[i] );
 
-		if (IEngineStudio.IsHardware() && // OpenGL mode
-			m_pCurrentEntity == gEngfuncs.GetViewModel() && // attachments of viewmodel
-			m_pCvarViewmodelFov->value != 0.0f && // viewmodel FOV is changed
-			g_flRenderFOV == gHUD.default_fov->value) // weapon is not zoomed in
+		if (m_pCurrentEntity == gEngfuncs.GetViewModel() && NeedAdjustViewmodelAdjustments())
 		{
 			// Adjust attachment positions to account for different viewmodel FOV.
 			// Otherwise weapon effects (sprites, beams) will be drawn in incorrect position.
 			StudioAdjustViewmodelAttachments(m_pCurrentEntity->attachment[i]);
 		}
 	}
+}
+
+bool CStudioModelRenderer::NeedAdjustViewmodelAdjustments()
+{
+	return IEngineStudio.IsHardware() && // OpenGL mode
+		m_pCvarViewmodelFov->value != 0.0f && // viewmodel FOV is changed.
+		g_flRenderFOV == gHUD.default_fov->value; // weapon is not zoomed in
 }
 
 void CStudioModelRenderer::StudioAdjustViewmodelAttachments(Vector &vOrigin)

--- a/cl_dll/StudioModelRenderer.h
+++ b/cl_dll/StudioModelRenderer.h
@@ -51,6 +51,9 @@ public:
 	// Find final attachment points
 	virtual void StudioCalcAttachments ( void );
 
+	// Returns whether StudioAdjustViewmodelAttachments needs to be called for the viewmodel
+	virtual bool NeedAdjustViewmodelAdjustments();
+
 	// Reprojects attachments of the viewmodel if FOV is changed
 	virtual void StudioAdjustViewmodelAttachments(Vector &vOrigin);
 	

--- a/cl_dll/ev_common.cpp
+++ b/cl_dll/ev_common.cpp
@@ -175,8 +175,19 @@ void EV_GetDefaultShellInfo( event_args_t *args, float *origin, float *velocity,
 	}
 
 	extern cvar_t* cl_righthand;
-	fR = (cl_righthand->value > 0.0f ? -1 : 1) * gEngfuncs.pfnRandomFloat( 50, 70 );
+	fR = gEngfuncs.pfnRandomFloat( 50, 70 );
 	fU = gEngfuncs.pfnRandomFloat( 100, 150 );
+
+	bool bIsFirstPerson = EV_IsPlayer(idx) && EV_IsLocal(idx);
+
+	if (bIsFirstPerson)
+	{
+		if (cl_righthand->value > 0.0f)
+		{
+			fR *= -1;
+			rightScale *= -1;
+		}
+	}
 
 	for ( i = 0; i < 3; i++ )
 	{

--- a/cl_dll/ev_common.cpp
+++ b/cl_dll/ev_common.cpp
@@ -26,6 +26,11 @@
 #include "pm_shared.h"
 
 #define IS_FIRSTPERSON_SPEC ( g_iUser1 == OBS_IN_EYE || (g_iUser1 && (gHUD.m_Spectator.m_pip->value == INSET_IN_EYE)) )
+
+extern cvar_t *cl_viewmodel_ofs_right;
+extern cvar_t *cl_viewmodel_ofs_forward;
+extern cvar_t *cl_viewmodel_ofs_up;
+
 /*
 =================
 GetEntity
@@ -182,6 +187,10 @@ void EV_GetDefaultShellInfo( event_args_t *args, float *origin, float *velocity,
 
 	if (bIsFirstPerson)
 	{
+		rightScale += cl_viewmodel_ofs_right->value;
+		forwardScale += cl_viewmodel_ofs_forward->value;
+		upScale += cl_viewmodel_ofs_up->value;
+
 		if (cl_righthand->value > 0.0f)
 		{
 			fR *= -1;

--- a/cl_dll/ev_common.cpp
+++ b/cl_dll/ev_common.cpp
@@ -24,12 +24,15 @@
 #include "eventscripts.h"
 #include "event_api.h"
 #include "pm_shared.h"
+#include "GameStudioModelRenderer.h"
 
 #define IS_FIRSTPERSON_SPEC ( g_iUser1 == OBS_IN_EYE || (g_iUser1 && (gHUD.m_Spectator.m_pip->value == INSET_IN_EYE)) )
 
 extern cvar_t *cl_viewmodel_ofs_right;
 extern cvar_t *cl_viewmodel_ofs_forward;
 extern cvar_t *cl_viewmodel_ofs_up;
+
+extern CGameStudioModelRenderer g_StudioRenderer;
 
 /*
 =================
@@ -154,7 +157,7 @@ EV_GetDefaultShellInfo
 Determine where to eject shells from
 =================
 */
-void EV_GetDefaultShellInfo( event_args_t *args, float *origin, float *velocity, float *ShellVelocity, float *ShellOrigin, float *forward, float *right, float *up, float forwardScale, float upScale, float rightScale )
+void EV_GetDefaultShellInfo( event_args_t *args, float *origin, float *velocity, float *ShellVelocity, Vector &ShellOrigin, float *forward, float *right, float *up, float forwardScale, float upScale, float rightScale )
 {
 	int i;
 	vec3_t view_ofs;
@@ -203,6 +206,9 @@ void EV_GetDefaultShellInfo( event_args_t *args, float *origin, float *velocity,
 		ShellVelocity[i] = velocity[i] + right[i] * fR + up[i] * fU + forward[i] * 25;
 		ShellOrigin[i]   = origin[i] + view_ofs[i] + up[i] * upScale + forward[i] * forwardScale + right[i] * rightScale;
 	}
+
+	if (bIsFirstPerson && g_StudioRenderer.NeedAdjustViewmodelAdjustments())
+		g_StudioRenderer.StudioAdjustViewmodelAttachments(ShellOrigin);
 }
 
 /*

--- a/cl_dll/ev_hldm.cpp
+++ b/cl_dll/ev_hldm.cpp
@@ -479,7 +479,7 @@ void EV_FireGlock1( event_args_t *args )
 		V_PunchAxis( 0, -2.0 );
 	}
 
-	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 4 );
+	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, 4 );
 
 	EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHELL ); 
 
@@ -524,7 +524,7 @@ void EV_FireGlock2( event_args_t *args )
 		V_PunchAxis( 0, -2.0 );
 	}
 
-	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 4 );
+	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, 4 );
 
 	EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHELL ); 
 
@@ -579,7 +579,7 @@ void EV_FireShotGunDouble( event_args_t *args )
 
 	for ( j = 0; j < 2; j++ )
 	{
-		EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 32, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 6 );
+		EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 32, -12, 6 );
 
 		EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHOTSHELL ); 
 	}
@@ -632,7 +632,7 @@ void EV_FireShotGunSingle( event_args_t *args )
 		V_PunchAxis( 0, -5.0 );
 	}
 
-	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 32, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 6 );
+	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 32, -12, 6 );
 
 	EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHOTSHELL ); 
 
@@ -689,7 +689,7 @@ void EV_FireMP5( event_args_t *args )
 		V_PunchAxis( 0, gEngfuncs.pfnRandomFloat( -2, 2 ) );
 	}
 
-	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, (cl_righthand->value > 0.0f ? -1 : 1) * 4 );
+	EV_GetDefaultShellInfo( args, origin, velocity, ShellVelocity, ShellOrigin, forward, right, up, 20, -12, 4 );
 
 	EV_EjectBrass ( ShellOrigin, ShellVelocity, angles[ YAW ], shell, TE_BOUNCE_SHELL ); 
 

--- a/cl_dll/eventscripts.h
+++ b/cl_dll/eventscripts.h
@@ -61,7 +61,7 @@
 // Some of these are HL/TFC specific?
 void EV_EjectBrass( float *origin, float *velocity, float rotation, int model, int soundtype );
 void EV_GetGunPosition( struct event_args_s *args, float *pos, float *origin );
-void EV_GetDefaultShellInfo( struct event_args_s *args, float *origin, float *velocity, float *ShellVelocity, float *ShellOrigin, float *forward, float *right, float *up, float forwardScale, float upScale, float rightScale );
+void EV_GetDefaultShellInfo( struct event_args_s *args, float *origin, float *velocity, float *ShellVelocity, Vector &ShellOrigin, float *forward, float *right, float *up, float forwardScale, float upScale, float rightScale );
 qboolean EV_IsLocal( int idx );
 qboolean EV_IsPlayer( int idx );
 void EV_CreateTracer( float *start, float *end );


### PR DESCRIPTION
Fixes a few issues with ejected shells and cl_viewmodel_* cvars.

1. Enabling left-handed mode inverted shell direction for other player models (which hold the weapon world model in the right hand).
2. cl_viewmodel_ofs cvars didn't offset shell spawn positions.
3. Shell positions weren't adjust for cl_viewmodel_fov.