### PR TITLE
Always render local player model when watching a POV demo with dem_forcehltv 1

### DIFF
--- a/cl_dll/in_camera.cpp
+++ b/cl_dll/in_camera.cpp
@@ -18,6 +18,7 @@
 #include "pm_shared.h"
 
 #include "port.h"
+#include "demo_api.h"
 
 float CL_KeyState (kbutton_t *key);
 
@@ -64,7 +65,6 @@ cvar_t	*c_maxyaw;
 cvar_t	*c_minyaw;
 cvar_t	*c_maxdistance;
 cvar_t	*c_mindistance;
-cvar_t	*dem_forcehltv_local_model;
 
 // pitch, yaw, dist
 vec3_t cam_ofs;
@@ -501,8 +501,6 @@ void CAM_Init( void )
 	c_minyaw				= gEngfuncs.pfnRegisterVariable ( "c_minyaw",   "-135.0", 0 );
 	c_maxdistance			= gEngfuncs.pfnRegisterVariable ( "c_maxdistance",   "200.0", 0 );
 	c_mindistance			= gEngfuncs.pfnRegisterVariable ( "c_mindistance",   "30.0", 0 );
-
-	dem_forcehltv_local_model = gEngfuncs.pfnRegisterVariable ( "dem_forcehltv_local_model", "0", 0 );
 }
 
 void CAM_ClearStates( void )
@@ -602,7 +600,7 @@ int CL_DLLEXPORT CL_IsThirdPerson( void )
 {
 //	RecClCL_IsThirdPerson();
 
-	if (dem_forcehltv_local_model->value != 0.0f && gEngfuncs.IsSpectateOnly() && g_iUser1 != OBS_IN_EYE)
+	if (gEngfuncs.pDemoAPI->IsPlayingback() && gEngfuncs.IsSpectateOnly() && g_iUser1 != OBS_IN_EYE)
 		return 1;
 
 	return (cam_thirdperson ? 1 : 0) || (g_iUser1 && (g_iUser2 == gEngfuncs.GetLocalPlayer()->index) );

--- a/cl_dll/in_camera.cpp
+++ b/cl_dll/in_camera.cpp
@@ -15,6 +15,7 @@
 #include "camera.h"
 #include "in_defs.h"
 #include "Exports.h"
+#include "pm_shared.h"
 
 #include "port.h"
 
@@ -63,6 +64,7 @@ cvar_t	*c_maxyaw;
 cvar_t	*c_minyaw;
 cvar_t	*c_maxdistance;
 cvar_t	*c_mindistance;
+cvar_t	*dem_forcehltv_local_model;
 
 // pitch, yaw, dist
 vec3_t cam_ofs;
@@ -499,6 +501,8 @@ void CAM_Init( void )
 	c_minyaw				= gEngfuncs.pfnRegisterVariable ( "c_minyaw",   "-135.0", 0 );
 	c_maxdistance			= gEngfuncs.pfnRegisterVariable ( "c_maxdistance",   "200.0", 0 );
 	c_mindistance			= gEngfuncs.pfnRegisterVariable ( "c_mindistance",   "30.0", 0 );
+
+	dem_forcehltv_local_model = gEngfuncs.pfnRegisterVariable ( "dem_forcehltv_local_model", "0", 0 );
 }
 
 void CAM_ClearStates( void )
@@ -597,6 +601,9 @@ void CAM_EndDistance(void)
 int CL_DLLEXPORT CL_IsThirdPerson( void )
 {
 //	RecClCL_IsThirdPerson();
+
+	if (dem_forcehltv_local_model->value != 0.0f && gEngfuncs.IsSpectateOnly() && g_iUser1 != OBS_IN_EYE)
+		return 1;
 
 	return (cam_thirdperson ? 1 : 0) || (g_iUser1 && (g_iUser2 == gEngfuncs.GetLocalPlayer()->index) );
 }


### PR DESCRIPTION
Hello. Tried to make the cvar name as close to the dem_forcehltv since it only applies to this (because in a real HLTV demo, the localplayer is the HLTV proxy and therefore all players are rendered correctly) and at the same time not too long.
This is basically this, but client DLL edition: https://github.com/YaLTeR/bxt-rs/issues/10 (https://github.com/advancedfx/advancedfx/blob/main/AfxHookGoldSrc/HltvFix.cpp)

Video:
https://user-images.githubusercontent.com/5108747/129068510-f3c7a689-5bce-4e59-bcf7-3fd655195948.mp4

