### PR TITLE
Added a CVAR to draw messages when hud_draw = 0

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -522,6 +522,7 @@ void CHud :: Init( void )
 	m_pCvarStealMouse = CVAR_CREATE( "hud_capturemouse", "1", FCVAR_ARCHIVE );
 	m_pCvarDraw = CVAR_CREATE( "hud_draw", "1", FCVAR_ARCHIVE );
 	m_pCvarDrawDeathNoticesAlways = CVAR_CREATE( "cl_draw_deathnotices_always", "0", FCVAR_ARCHIVE );
+	m_pCvarDrawMessagesAlways = CVAR_CREATE( "cl_draw_messages_always", "0", FCVAR_ARCHIVE );
 	m_pCvarAutostop = CVAR_CREATE("cl_autostop", "0", FCVAR_ARCHIVE);
 	m_pCvarViewheightMode = CVAR_CREATE("cl_viewheight_mode", "0", FCVAR_ARCHIVE);
 	m_pCvarHideCorpses = CVAR_CREATE("cl_hidecorpses", "0", FCVAR_ARCHIVE);

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -590,6 +590,7 @@ public:
 	cvar_t  *m_pCvarStealMouse;
 	cvar_t	*m_pCvarDraw;
 	cvar_t	*m_pCvarDrawDeathNoticesAlways;
+	cvar_t	*m_pCvarDrawMessagesAlways;
 	cvar_t	*m_pCvarAutostop;
 	cvar_t	*m_pCvarViewheightMode;
 	cvar_t	*m_pCvarHideCorpses;

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -205,6 +205,10 @@ int CHud :: Redraw( float flTime, int intermission )
 			if (gHUD.m_pCvarDrawDeathNoticesAlways->value != 0.0f
 				&& m_DeathNotice.m_iFlags & HUD_ACTIVE)
 				m_DeathNotice.Draw(flTime);
+				
+			if (gHUD.m_pCvarDrawMessagesAlways->value != 0.0f
+				&& m_Message.m_iFlags & HUD_ACTIVE)
+				m_Message.Draw(flTime);
 		}
 	}
 

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -202,6 +202,9 @@ int CHud :: Redraw( float flTime, int intermission )
 			if (m_Speedometer.m_iFlags & HUD_ACTIVE)
 				m_Speedometer.Draw(flTime);
 
+			if (m_Jumpspeed.m_iFlags & HUD_ACTIVE)
+				m_Jumpspeed.Draw(flTime);
+
 			if (gHUD.m_pCvarDrawDeathNoticesAlways->value != 0.0f
 				&& m_DeathNotice.m_iFlags & HUD_ACTIVE)
 				m_DeathNotice.Draw(flTime);


### PR DESCRIPTION
Makes HL KreedZ HUDs draw even when hud_draw is 0: ![20210903151618_1](https://user-images.githubusercontent.com/58108407/131997094-f19c116b-d8eb-4023-8e13-9351a3a67765.jpg)
