### PR TITLE
Add hud_jumpspeed_height and hud_speedometer_height cvars

### DIFF
--- a/cl_dll/hud_jumpspeed.cpp
+++ b/cl_dll/hud_jumpspeed.cpp
@@ -14,6 +14,7 @@ int CHudJumpspeed::Init()
 
 	hud_jumpspeed = CVAR_CREATE("hud_jumpspeed", "0", FCVAR_ARCHIVE);
 	hud_jumpspeed_below_cross = CVAR_CREATE("hud_jumpspeed_below_cross", "0", FCVAR_ARCHIVE);
+	hud_jumpspeed_height = CVAR_CREATE("hud_jumpspeed_height", "0", FCVAR_ARCHIVE);
 
 	gHUD.AddHudElem(this);
 	return 0;
@@ -36,6 +37,8 @@ int CHudJumpspeed::Draw(float flTime)
 	int y;
 	if (hud_jumpspeed_below_cross->value != 0.0f)
 		y = ScreenHeight / 2 + gHUD.m_iFontHeight / 2 + gHUD.m_iFontHeight;
+	else if (hud_jumpspeed_height->value != 0.0f)
+		y = hud_jumpspeed_height->value;
 	else
 		y = ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2;
 

--- a/cl_dll/hud_jumpspeed.h
+++ b/cl_dll/hud_jumpspeed.h
@@ -7,6 +7,7 @@ class CHudJumpspeed : public CHudBase
 
 	cvar_t* hud_jumpspeed;
 	cvar_t* hud_jumpspeed_below_cross;
+	cvar_t* hud_jumpspeed_height;
 
 	int fadingFrom[3];
 	float prevVel[3] = { 0.0f, 0.0f, 0.0f };

--- a/cl_dll/hud_speedometer.cpp
+++ b/cl_dll/hud_speedometer.cpp
@@ -12,6 +12,7 @@ int CHudSpeedometer::Init()
 
 	hud_speedometer = CVAR_CREATE("hud_speedometer", "0", FCVAR_ARCHIVE);
 	hud_speedometer_below_cross = CVAR_CREATE("hud_speedometer_below_cross", "0", FCVAR_ARCHIVE);
+	hud_speedometer_height = CVAR_CREATE("hud_speedometer_height", "0", FCVAR_ARCHIVE);
 
 	gHUD.AddHudElem(this);
 	return 0;
@@ -31,8 +32,10 @@ int CHudSpeedometer::Draw(float time)
 	UnpackRGB(r, g, b, gHUD.m_iDefaultHUDColor);
 
 	int y;
-	if (hud_speedometer_below_cross->value != 0)
+	if (hud_speedometer_below_cross->value != 0.0f)
 		y = ScreenHeight / 2 + gHUD.m_iFontHeight / 2;
+	else if (hud_speedometer_height->value != 0.0f)
+		y = hud_speedometer_height->value;
 	else
 		y = ScreenHeight - gHUD.m_iFontHeight - gHUD.m_iFontHeight / 2 - gHUD.m_iFontHeight;
 

--- a/cl_dll/hud_speedometer.h
+++ b/cl_dll/hud_speedometer.h
@@ -7,6 +7,7 @@ class CHudSpeedometer : public CHudBase
 
 	cvar_t* hud_speedometer;
 	cvar_t* hud_speedometer_below_cross;
+	cvar_t* hud_speedometer_height;
 
 public:
 	virtual int Init();


### PR DESCRIPTION
Since previous update changed default speedometer position there are some players (including me) who want to get it back and being able to move it whatever you want in general