### PR TITLE
Fix watermark not disappearing when playing back demo with viewdemo

### DIFF
--- a/cl_dll/hud_watermark.cpp
+++ b/cl_dll/hud_watermark.cpp
@@ -22,7 +22,7 @@ int CHudWatermark::VidInit()
 
 int CHudWatermark::Draw(float time)
 {
-	if (refresh_draw_until) {
+	if (refresh_draw_until || (draw_until > gHUD.m_flTime + 15.0f)) {
 		refresh_draw_until = false;
 		draw_until = gHUD.m_flTime + 15.0f;
 	}


### PR DESCRIPTION
For `playdemo` and normal gameplay the `time` float is correct on the first Draw() frame, this however isn't true for `viewdemo`, where it starts on the correct "server time" from that demo (e.g. `331`) for a few frames, but then resets itself to 0 and starts adding up, this results in the 15 second offset for hiding the watermark message being set to e.g. 331 + 15 = 346, but `time` is then counting from 0, resulting in the watermark not disappearing for 346 more seconds when using `viewdemo`.


