### PR TITLE
Strafing HUD

### DIFF
--- a/cl_dll/CMakeLists.txt
+++ b/cl_dll/CMakeLists.txt
@@ -69,6 +69,8 @@ add_sources(
 	hud_spectator.h
 	hud_speedometer.cpp
 	hud_speedometer.h
+	hud_strafeguide.cpp
+	hud_strafeguide.h
 	hud_suddendeath.cpp
 	hud_suddendeath.h
 	hud_timeout.cpp

--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -148,7 +148,7 @@ void CL_DLLEXPORT HUD_PlayerMove( struct playermove_s *ppmove, int server )
 {
 //	RecClClientMove(ppmove, server);
 
-	gHUD.m_StrafeGuide.Update(ppmove);
+	//~ gHUD.m_StrafeGuide.Update(ppmove);
 	PM_Move( ppmove, server );
 }
 

--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -148,6 +148,7 @@ void CL_DLLEXPORT HUD_PlayerMove( struct playermove_s *ppmove, int server )
 {
 //	RecClClientMove(ppmove, server);
 
+	gHUD.m_StrafeGuide.Update(ppmove);
 	PM_Move( ppmove, server );
 }
 

--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -148,7 +148,6 @@ void CL_DLLEXPORT HUD_PlayerMove( struct playermove_s *ppmove, int server )
 {
 //	RecClClientMove(ppmove, server);
 
-	//~ gHUD.m_StrafeGuide.Update(ppmove);
 	PM_Move( ppmove, server );
 }
 

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -574,6 +574,7 @@ void CHud :: Init( void )
 	m_Scores.Init();
 	m_Settings.Init();
 	m_Speedometer.Init();
+	m_StrafeGuide.Init();
 	m_SuddenDeath.Init();
 	m_Timeout.Init();
 	m_Timer.Init();

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -105,6 +105,7 @@ struct HUDLIST {
 #include "hud_scores.h"
 #include "hud_settings.h"
 #include "hud_speedometer.h"
+#include "hud_strafeguide.h"
 #include "hud_suddendeath.h"
 #include "hud_timeout.h"
 #include "hud_timer.h"
@@ -684,6 +685,7 @@ public:
 	CHudScores	m_Scores;
 	CHudSettings	m_Settings;
 	CHudSpeedometer	m_Speedometer;
+	CHudStrafeGuide	m_StrafeGuide;
 	CHudJumpspeed   m_Jumpspeed;
 	CHudSuddenDeath		m_SuddenDeath;
 	CHudTimeout		m_Timeout;

--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -201,6 +201,9 @@ int CHud :: Redraw( float flTime, int intermission )
 
 			if (m_Speedometer.m_iFlags & HUD_ACTIVE)
 				m_Speedometer.Draw(flTime);
+				
+			if (m_StrafeGuide.m_iFlags & HUD_ACTIVE)
+				m_StrafeGuide.Draw(flTime);
 
 			if (m_Jumpspeed.m_iFlags & HUD_ACTIVE)
 				m_Jumpspeed.Draw(flTime);

--- a/cl_dll/hud_strafeguide.cpp
+++ b/cl_dll/hud_strafeguide.cpp
@@ -1,3 +1,5 @@
+#define _USE_MATH_DEFINES
+#include <cmath>
 #include <complex>
 
 #include "hud.h"
@@ -75,7 +77,7 @@ int CHudStrafeGuide::Draw(float time)
 			boxLeft  *= zoom;
 			boxRight *= zoom;
 			
-			if (std::abs(boxLeft) > fov && std::abs(boxRight) > fov)
+			if (std::abs(boxLeft) > fov && std::abs(boxRight) > fov && boxRight * boxLeft > 0)
 				continue;
 			
 			boxLeft  = boxLeft  > fov ? fov : boxLeft  < -fov ? -fov : boxLeft;

--- a/cl_dll/hud_strafeguide.cpp
+++ b/cl_dll/hud_strafeguide.cpp
@@ -1,0 +1,160 @@
+#include <complex>
+
+#include "hud.h"
+#include "cl_util.h"
+#include "parsemsg.h"
+#include "hudgl.h"
+
+#include "pm_defs.h"
+#include "usercmd.h"
+#include "pm_movevars.h"
+
+enum border {
+	RED_GREEN,
+	GREEN_WHITE,
+	WHITE_GREEN,
+	GREEN_RED
+};
+
+const float pi = std::acos(-1.);
+
+int CHudStrafeGuide::Init()
+{
+	m_iFlags = HUD_ACTIVE;
+
+	hud_strafeguide = CVAR_CREATE("hud_strafeguide", "0", FCVAR_ARCHIVE);
+
+	gHUD.AddHudElem(this);
+	return 0;
+}
+
+int CHudStrafeGuide::VidInit()
+{
+	return 1;
+}
+
+
+
+int CHudStrafeGuide::Draw(float time)
+{
+	if (hud_strafeguide->value == 0)
+		return 0;
+	
+	double fov = 140./ 2 / 180 * pi;
+	
+	int fontHeight = gHUD.m_iFontHeight;
+	
+	for (int i = 0; i < 4; ++i) {
+		int r, g, b;
+		switch (i) {
+			case RED_GREEN: case WHITE_GREEN:
+				r = 0; g = 255; b = 0; break;
+			case GREEN_WHITE:
+				r = 255; g = 255; b = 255; break;
+			case GREEN_RED:
+				r = 255; g = 0; b = 0; break;
+		}
+		
+		double boxLeft  = -angles[i];
+		double boxRight = -angles[(i+1)%4];
+		if (boxLeft == boxRight)
+			continue;
+		
+		if (boxLeft > fov) {
+			if (boxRight < -fov || boxRight > boxLeft)
+				continue;
+			boxLeft = -fov;
+		}
+		else if (boxRight < -fov) {
+			if (boxLeft < boxRight)
+				continue;
+			boxRight = fov;
+		}
+		if (boxLeft  < -fov) boxLeft  = -fov;
+		if (boxRight >  fov) boxRight = fov;
+		
+		int boxLeftI  = boxLeft / fov * ScreenWidth / 2;
+		int boxRightI = boxRight/ fov * ScreenWidth / 2;
+		boxLeftI  += ScreenWidth / 2;
+		boxRightI += ScreenWidth / 2;
+		
+		FillRGBA(boxLeftI, ScreenHeight*.48, boxRightI-boxLeftI, fontHeight, r, g, b, 60);
+	}
+	
+	ConsolePrint(debug);
+	sprintf(debug, "Angles: %f %f %f %f\n", angles[0], angles[1], angles[2], angles[3]);
+	ConsolePrint(debug);
+	
+	return 0;
+}
+
+
+static double angleReduce(double a)
+{
+	double tmp = std::fmod(a, 2*pi);
+	if (tmp < 0) tmp += 2*pi;
+	if (tmp > M_PI) tmp -= 2*pi;
+	return tmp;
+}
+
+void CHudStrafeGuide::Update(struct playermove_s *ppmove)
+{
+	auto iUnit = std::complex<double>(0., 1.);
+	double frameTime = ppmove->frametime;
+	auto input = std::complex<double>(ppmove->cmd.forwardmove, ppmove->cmd.sidemove);
+	double viewAngle = ppmove->angles[1] / 180 * pi;
+	
+	if (std::norm(input) == 0) {
+		for (int i = 0; i < 4; ++i) {
+			if (i < 2)
+				angles[i] = pi;
+			else
+				angles[i] = -pi;
+		}
+		return;
+	}
+
+	//~ sprintf(debug, "angle %f lastangle %f input %f %f ftime %f rotvel %f\n", viewAngle, lastViewAngle, input.real(), input.imag(), frameTime, actualRotVel);
+	
+	auto velocity = std::complex<double>(ppmove->velocity[0], ppmove->velocity[1]);
+
+	
+	bool onground = ppmove->onground;
+	double accelCoeff = onground ? ppmove->movevars->accelerate : ppmove->movevars->airaccelerate;
+	double frictionCoeff = ppmove->friction;
+	double speedCap = onground ? ppmove->maxspeed : min(ppmove->maxspeed, 30);
+	
+	
+	double inputAbs = min(std::abs(input), ppmove->maxspeed);
+	input *= inputAbs / std::abs(input);
+	double uncappedAccel = accelCoeff * frictionCoeff * inputAbs * frameTime;
+	double velocityAbs = std::abs(velocity);
+	
+	if (velocityAbs == 0)
+		angles[RED_GREEN] = pi;
+	else
+		angles[RED_GREEN] = std::acos(-uncappedAccel / velocityAbs / 2);
+	
+	if (velocityAbs <= speedCap)
+		angles[GREEN_WHITE] = 0;
+	else 
+		angles[GREEN_WHITE] = std::acos(speedCap / velocityAbs);
+	
+	angles[GREEN_RED] = -angles[RED_GREEN];
+	angles[WHITE_GREEN] = -angles[GREEN_WHITE];
+	
+	double inputAngle = std::log(input).imag();
+	double velocityAngle;
+	
+	if (velocityAbs == 0)
+		velocityAngle = 0;
+	else
+		velocityAngle = std::log(velocity).imag();
+	
+	for (int i = 0; i < 4; ++i) {
+		angles[i] += velocityAngle + inputAngle - viewAngle;
+		angles[i] = angleReduce(angles[i]);
+	}
+	
+	sprintf(debug, "inp %f %f, vel %f %f, view %f\n", input.real(), input.imag(), velocity.real(), velocity.imag(), viewAngle);
+}

--- a/cl_dll/hud_strafeguide.h
+++ b/cl_dll/hud_strafeguide.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <complex>
+
+class CHudStrafeGuide : public CHudBase
+{
+	double angles[6];
+	
+	char debug[256] = "";
+	
+	cvar_t* hud_strafeguide;
+	
+public:
+	virtual int Init();
+	virtual int VidInit();
+	virtual int Draw(float time);
+
+	void Update(struct playermove_s *ppmove);
+};

--- a/cl_dll/hud_strafeguide.h
+++ b/cl_dll/hud_strafeguide.h
@@ -8,7 +8,7 @@ class CHudStrafeGuide : public CHudBase
 	std::complex<double> lastSimvel = 0.;
 	
 	cvar_t* hud_strafeguide;
-	cvar_t* hud_strafeguide_fov;
+	cvar_t* hud_strafeguide_zoom;
 	cvar_t* hud_strafeguide_height;
 	cvar_t* hud_strafeguide_size;
 	

--- a/cl_dll/hud_strafeguide.h
+++ b/cl_dll/hud_strafeguide.h
@@ -3,16 +3,19 @@
 
 class CHudStrafeGuide : public CHudBase
 {
-	double angles[6];
+	double angles[6] = {0.};
 	
-	char debug[256] = "";
+	std::complex<double> lastSimvel = 0.;
 	
 	cvar_t* hud_strafeguide;
+	cvar_t* hud_strafeguide_fov;
+	cvar_t* hud_strafeguide_height;
+	cvar_t* hud_strafeguide_size;
 	
 public:
 	virtual int Init();
 	virtual int VidInit();
 	virtual int Draw(float time);
 
-	void Update(struct playermove_s *ppmove);
+	void Update(struct ref_params_s *ppmove);
 };

--- a/cl_dll/view.cpp
+++ b/cl_dll/view.cpp
@@ -1699,6 +1699,7 @@ void CL_DLLEXPORT V_CalcRefdef( struct ref_params_s *pparams )
 //	RecClCalcRefdef(pparams);
 
 	gHUD.m_Speedometer.UpdateSpeed(pparams->simvel);
+	gHUD.m_StrafeGuide.Update(pparams);
 	gHUD.m_Jumpspeed.UpdateSpeed(pparams->simvel);
 
 	// intermission / finale rendering


### PR DESCRIPTION
![strafe hud demo](https://user-images.githubusercontent.com/81391208/143658302-a4a354cd-0d07-4687-85cb-006c64486d3e.jpg)
This was suggested before in #53. Basically, the center of the bar tells you whether you're accelerating (green), decelerating (red), or neither (white). Note that this doesn't take into account ground friction (yet).
`hud_strafeguide 1` to enable. `hud_strafeguide_fov`, `hud_strafeguide_height`, `hud_strafeguide_size` to manipulate.
I don't think this is anywhere near as useful as the Defrag HUDs people use, unless you're a strafing god you'll likely be almost always stuck at the edge between green and white. Suggestions on how to improve this are welcome, this is more of a prototype than anything else. I might add an indicator for the region of maximum acceleration, that could make it more useful at least for circle jumping.
But at least it looks cool.