### PR TITLE
Add cvars to ignore certain messages

### DIFF
--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -418,6 +418,8 @@ struct message_parms_t
 
 class CHudTextMessage: public CHudBase
 {
+	std::vector<cvar_t*> ignored_message_types;
+
 public:
 	int Init( void );
 	static char *LocaliseTextString( const char *msg, char *dst_buffer, int buffer_size );

--- a/cl_dll/text_message.cpp
+++ b/cl_dll/text_message.cpp
@@ -34,6 +34,9 @@ int CHudTextMessage::Init(void)
 {
 	HOOK_MESSAGE( TextMsg );
 
+	ignored_message_types.push_back(CVAR_CREATE("cl_ignore_spawn_messages", "0", FCVAR_ARCHIVE));
+	ignored_message_types.push_back(CVAR_CREATE("cl_ignore_damage_messages", "0", FCVAR_ARCHIVE));
+
 	gHUD.AddHudElem( this );
 
 	Reset();
@@ -155,6 +158,7 @@ char* ConvertCRtoNL( char *str )
 //   string: message parameter 2
 //   string: message parameter 3
 //   string: message parameter 4
+//   byte:   message type
 // any string that starts with the character '#' is a message name, and is used to look up the real message in titles.txt
 // the next (optional) one to four strings are parameters for that string (which can also be message names if they begin with '#')
 int CHudTextMessage::MsgFunc_TextMsg( const char *pszName, int iSize, void *pbuf )
@@ -185,6 +189,13 @@ int CHudTextMessage::MsgFunc_TextMsg( const char *pszName, int iSize, void *pbuf
 
 	if ( gViewPort && gViewPort->AllowedToPrintText() == FALSE )
 		return 1;
+
+	const auto type = READ_BYTE(); // -1 if absent
+	if (type >= 0 && type < ignored_message_types.size()
+		&& ignored_message_types[type]->value != 0.0f)
+	{
+		return 1;
+	}
 
 	switch ( msg_dest )
 	{


### PR DESCRIPTION
With the next version of AG an extra byte will be sent on the TextMsg event. This byte tells what type of message it is. For the moment I have added 2 message types, and I'm planning a few more in the future, like a type for name and/or team changing messages. This makes it possible to ignore certain types of messages easily in the client, without relying on server configuration or checking what kind of text the message has.

This byte will be:
-1: if absent (that's what READ_BYTE() returns if it ran out of bytes to read)
0: if it's a spawn message
1: if it's a damage message

A spawn message is sent as soon as a practice bot respawns, telling the spot number where it spawned.
A damage message tells how much damage you dealt to a practice bot.

New cvars:

- `cl_ignore_spawn_messages` <0/1> - Default: 0 (don't ignore this message type)
- `cl_ignore_damage_messages` <0/1> - Default: 0 (don't ignore this message type)

As I mentioned there will be more types, for name/team changes, as some players have requested the ability to ignore those because some spectators like to change their name/model to distract players during a match, or to give unfair advantage to one of them telling the opponent's location.

Any suggestion is very welcome, regarding anything really (cvar names, coding, ignoring strategy, etc.). My C++ knowledge is very limited as you know :)
