### PR TITLE
Register showtriggers as client command

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -528,6 +528,7 @@ void CHud :: Init( void )
 	m_pCvarHideCorpses = CVAR_CREATE("cl_hidecorpses", "0", FCVAR_ARCHIVE);
 	m_pCvarColor = CVAR_CREATE( "hud_color", "", FCVAR_ARCHIVE );
 	cl_lw = gEngfuncs.pfnGetCvarPointer( "cl_lw" );
+	CVAR_CREATE("showtriggers", "0", 0);
 
 	m_pSpriteList = NULL;
 


### PR DESCRIPTION
Allows to show map triggers on a local server, useful for researching without map editors or 3rd-party tools:

https://user-images.githubusercontent.com/58108407/151686645-99e22ec4-320c-47b1-8eb1-1f4db86a5ffa.mp4

In WON era, `showtriggers` been registered on engine side, but with updates later it's been removed, let's get it back now :)

It works cuz there are still some calls to `showtriggers` cmd in the server side, but the command itself is not declared in latest HLSDK:

https://github.com/YaLTeR/OpenAG/blob/061c06cfb5cc0e837c4063aa4dcedd9fe7d286bc/dlls/bmodels.cpp#L267-L268
https://github.com/YaLTeR/OpenAG/blob/061c06cfb5cc0e837c4063aa4dcedd9fe7d286bc/dlls/triggers.cpp#L554-L555
https://github.com/YaLTeR/OpenAG/blob/061c06cfb5cc0e837c4063aa4dcedd9fe7d286bc/dlls/triggers.cpp#L1767-L1771