### PR TITLE
Added r_drawentities 5 for hardware rendering

### DIFF
--- a/cl_dll/StudioModelRenderer.cpp
+++ b/cl_dll/StudioModelRenderer.cpp
@@ -2225,6 +2225,11 @@ void CStudioModelRenderer::StudioRenderFinal_Hardware( void )
 		gEngfuncs.pTriAPI->RenderMode( kRenderNormal );
 	}
 
+	if ( m_pCvarDrawEntities->value == 5 )
+	{
+		IEngineStudio.StudioDrawAbsBBox( );
+	}
+
 	IEngineStudio.RestoreRenderer();
 }
 


### PR DESCRIPTION
Allows to draw absbox of entities in hardware mode, could be used for some of research.

![drawentities5](https://user-images.githubusercontent.com/58108407/154583560-b0f0c7b6-c08b-4f7d-9398-d8d77e1ca541.png)

That mode been added for SW a long time ago: https://github.com/YaLTeR/OpenAG/blob/e5bea9eba6836a2d9a8436f3b8103ef7d74a717e/cl_dll/StudioModelRenderer.cpp#L2137-L2140

... but for HW rendering it probably forgotten to add. 