### PR TITLE
Added cl_team_sounds_volume

### DIFF
--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -196,8 +196,7 @@ int __MsgFunc_PlaySound(const char* name, int size, void* buf)
 		origin[i] = READ_COORD();
 
 	const auto sound = READ_STRING();
-	if (gHUD.m_pCvarIgnoreSoundMessages->value == 0.0f)
-		gEngfuncs.pfnPlaySoundByName(sound, 1);
+	gEngfuncs.pfnPlaySoundByName(sound, gHUD.m_pCvarPlayTeamSoundsVolume->value);
 
 	return 1;
 }
@@ -528,7 +527,7 @@ void CHud :: Init( void )
 	m_pCvarViewheightMode = CVAR_CREATE("cl_viewheight_mode", "0", FCVAR_ARCHIVE);
 	m_pCvarHideCorpses = CVAR_CREATE("cl_hidecorpses", "0", FCVAR_ARCHIVE);
 	m_pCvarColor = CVAR_CREATE( "hud_color", "", FCVAR_ARCHIVE );
-	m_pCvarIgnoreSoundMessages = CVAR_CREATE("cl_ignore_playsound_messages", "0", FCVAR_ARCHIVE);
+	m_pCvarPlayTeamSoundsVolume = CVAR_CREATE("cl_team_sounds_volume", "1.0", FCVAR_ARCHIVE);
 	cl_lw = gEngfuncs.pfnGetCvarPointer( "cl_lw" );
 
 	m_pSpriteList = NULL;

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -196,7 +196,8 @@ int __MsgFunc_PlaySound(const char* name, int size, void* buf)
 		origin[i] = READ_COORD();
 
 	const auto sound = READ_STRING();
-	gEngfuncs.pfnPlaySoundByName(sound, 1);
+	if (gHUD.m_pCvarIgnoreSoundMessages->value == 0.0f)
+		gEngfuncs.pfnPlaySoundByName(sound, 1);
 
 	return 1;
 }
@@ -527,6 +528,7 @@ void CHud :: Init( void )
 	m_pCvarViewheightMode = CVAR_CREATE("cl_viewheight_mode", "0", FCVAR_ARCHIVE);
 	m_pCvarHideCorpses = CVAR_CREATE("cl_hidecorpses", "0", FCVAR_ARCHIVE);
 	m_pCvarColor = CVAR_CREATE( "hud_color", "", FCVAR_ARCHIVE );
+	m_pCvarIgnoreSoundMessages = CVAR_CREATE("cl_ignore_playsound_messages", "0", FCVAR_ARCHIVE);
 	cl_lw = gEngfuncs.pfnGetCvarPointer( "cl_lw" );
 
 	m_pSpriteList = NULL;

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -596,7 +596,7 @@ public:
 	cvar_t	*m_pCvarAutostop;
 	cvar_t	*m_pCvarViewheightMode;
 	cvar_t	*m_pCvarHideCorpses;
-	cvar_t	*m_pCvarIgnoreSoundMessages;
+	cvar_t	*m_pCvarPlayTeamSoundsVolume;
 
 	int m_iFontHeight;
 

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -596,6 +596,7 @@ public:
 	cvar_t	*m_pCvarAutostop;
 	cvar_t	*m_pCvarViewheightMode;
 	cvar_t	*m_pCvarHideCorpses;
+	cvar_t	*m_pCvarIgnoreSoundMessages;
 
 	int m_iFontHeight;
 


### PR DESCRIPTION
Hello.

**Motivation:**
This is useful against `play_team` and `play_close` "spamming" _[quotation marks because each sound gets replaced by the previous one]_ both of which send `PlaySound` UserMsg to players on your team and players on your team that are close to you, respectively. While this can be useful for normal DM for e.g. notifying about dropping weapons to your teammates with a specific sound, etc. it can get annoying on HLKreedz and other gamemodes, therefore this PR introduces a cvar to toggle being bombarded with sounds.

**Video:**
https://user-images.githubusercontent.com/5108747/157968525-dd9c54cf-2300-4e3d-80ee-63c6722c3a59.mp4



**What this disables:**
Just `play_team` and `play_close`, the usermsg isn't used anywhere else in the ServerDLL for any other sounds.
Proof:
user msg reg
https://github.com/fireblizzard/agmod/blob/9dfa990c95ee37a7d5370d5f834220f80da4dd11/src/dlls/player.cpp#L279
(and then the msg isn't used anywhere else)
AgClient::Play call:
https://github.com/fireblizzard/agmod/blob/9dfa990c95ee37a7d5370d5f834220f80da4dd11/src/dlls/agclient.cpp#L237
AgClient::Play code:
https://github.com/fireblizzard/agmod/blob/989b156b6583b5c1ce6d815284714efa595c7b9c/dlls/agclient.cpp#L779

