### PR TITLE
Added cl_hide_other_players

### DIFF
--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -14,6 +14,7 @@
 #include "pm_shared.h"
 #include "bench.h"
 #include "Exports.h"
+#include "demo_api.h"
 
 #include "discord_integration.h"
 
@@ -62,6 +63,9 @@ int CL_DLLEXPORT HUD_AddEntity( int type, struct cl_entity_s *ent, const char *m
 	// in spectator mode:
 	// each frame every entity passes this function, so the overview hooks 
 	// it to filter the overview entities
+
+	if (gHUD.m_pCvarHideOtherPlayers->value > 0 && ent->player && gEngfuncs.pDemoAPI->IsPlayingback() && ent->index != g_iUser2)
+		return 0;
 
 	if ( g_iUser1 )
 	{

--- a/cl_dll/hud.cpp
+++ b/cl_dll/hud.cpp
@@ -526,6 +526,7 @@ void CHud :: Init( void )
 	m_pCvarAutostop = CVAR_CREATE("cl_autostop", "0", FCVAR_ARCHIVE);
 	m_pCvarViewheightMode = CVAR_CREATE("cl_viewheight_mode", "0", FCVAR_ARCHIVE);
 	m_pCvarHideCorpses = CVAR_CREATE("cl_hidecorpses", "0", FCVAR_ARCHIVE);
+	m_pCvarHideOtherPlayers = CVAR_CREATE("cl_hide_other_players", "0", 0);
 	m_pCvarColor = CVAR_CREATE( "hud_color", "", FCVAR_ARCHIVE );
 	m_pCvarPlayTeamSoundsVolume = CVAR_CREATE("cl_team_sounds_volume", "1.0", FCVAR_ARCHIVE);
 	cl_lw = gEngfuncs.pfnGetCvarPointer( "cl_lw" );

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -599,6 +599,7 @@ public:
 	cvar_t	*m_pCvarAutostop;
 	cvar_t	*m_pCvarViewheightMode;
 	cvar_t	*m_pCvarHideCorpses;
+	cvar_t	*m_pCvarHideOtherPlayers;
 	cvar_t	*m_pCvarPlayTeamSoundsVolume;
 
 	int m_iFontHeight;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5108747/195437805-c625e737-bb21-4f61-abd9-413a812d0704.png)

(Some additional info on his use case is: 1) doesnt hide players on HLKZ when playin', 2) recorded POV demo, 3) got a good run, 4) wanted to render POV demo, but now the other player is visible on the demo 5) sadface 6) this pr)

* No FCVAR_ARCHIVE so ppl dont forget that they hid players and wonder "wtf where players at"