### PR TITLE
Make hud_saytext draw even when hud_draw is 0

### DIFF
--- a/cl_dll/hud_redraw.cpp
+++ b/cl_dll/hud_redraw.cpp
@@ -208,6 +208,9 @@ int CHud :: Redraw( float flTime, int intermission )
 			if (m_Jumpspeed.m_iFlags & HUD_ACTIVE)
 				m_Jumpspeed.Draw(flTime);
 
+			if (m_SayText.m_iFlags & HUD_ACTIVE)
+				m_SayText.Draw(flTime);
+
 			if (gHUD.m_pCvarDrawDeathNoticesAlways->value != 0.0f
 				&& m_DeathNotice.m_iFlags & HUD_ACTIVE)
 				m_DeathNotice.Draw(flTime);


### PR DESCRIPTION
Can be useful for recording some HLKZ runs (because there is always chat output of run time/top in leaderboard)