### PR TITLE
Make name/team change and game leave messages ignorable

### DIFF
--- a/cl_dll/text_message.cpp
+++ b/cl_dll/text_message.cpp
@@ -38,6 +38,9 @@ int CHudTextMessage::Init(void)
 
 	ignored_message_types.push_back(CVAR_CREATE("cl_ignore_spawn_messages", "0", FCVAR_ARCHIVE));
 	ignored_message_types.push_back(CVAR_CREATE("cl_ignore_damage_messages", "0", FCVAR_ARCHIVE));
+	ignored_message_types.push_back(CVAR_CREATE("cl_ignore_name_change_messages", "0", FCVAR_ARCHIVE));
+	ignored_message_types.push_back(CVAR_CREATE("cl_ignore_team_change_messages", "0", FCVAR_ARCHIVE));
+	ignored_message_types.push_back(CVAR_CREATE("cl_ignore_game_leave_messages", "0", FCVAR_ARCHIVE));
 
 	m_pCvarHideCenterMessages = CVAR_CREATE( "cl_hide_center_messages", "0", FCVAR_ARCHIVE );
 


### PR DESCRIPTION
AG 6.7 sends a byte for these chat message types that we can use to ignore them