### PR TITLE
Make sure the client is linked to libSDL2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,7 @@ elseif(UNIX)
 		# I wasn't able to do this in any other way.
 		# Things like imported targets result in linking with relative path.
 		set(VGUI_LINK_FLAGS "-L${CMAKE_SOURCE_DIR}/linux/release -l:vgui.so")
+		set(SDL2_LINK_FLAGS "-L${CMAKE_SOURCE_DIR}/linux -lSDL2")
 
 		# --push-state isn't supported on older compilers. I tried checking for support
 		# using CheckCXXCompilerFlag and CheckCXXSourceCompiles, but they were reporting
@@ -210,7 +211,7 @@ elseif(UNIX)
 		# --no-as-needed for all compilers.
 		set(VGUI_LINK_FLAGS "-Wl,--no-as-needed ${VGUI_LINK_FLAGS}")
 
-		set_property(TARGET client PROPERTY LINK_FLAGS ${VGUI_LINK_FLAGS})
+		set_property(TARGET client PROPERTY LINK_FLAGS "${VGUI_LINK_FLAGS} ${SDL2_LINK_FLAGS}")
 	endif(APPLE)
 endif(WIN32)
 


### PR DESCRIPTION
The client.so must be explicitly linked to libSDL2, just like valve/cl_dlls/client.so.
Related issue: https://github.com/YaLTeR/OpenAG/issues/181