### PR TITLE
Replace cuboid with polygons drawing for triggers on hardware engine if the model data available

### DIFF
--- a/cl_dll/cdll_int.cpp
+++ b/cl_dll/cdll_int.cpp
@@ -151,6 +151,25 @@ void CL_DLLEXPORT HUD_PlayerMove( struct playermove_s *ppmove, int server )
 	PM_Move( ppmove, server );
 }
 
+void SaveEngineVersion()
+{
+	cvar_t *sv_version = gEngfuncs.pfnGetCvarPointer("sv_version");
+	if (sv_version)
+	{
+		strncpy(gHUD.m_szEngineVersion, sv_version->string, sizeof(gHUD.m_szEngineVersion) - 1);
+
+		// Parse build number
+		std::string version = gHUD.m_szEngineVersion;
+		size_t lastComma = version.rfind(',');
+		
+		if (lastComma != std::string::npos)
+		{
+			const char *buildStr = gHUD.m_szEngineVersion + lastComma + 1;
+			gHUD.m_iEngineBuildNumber = atoi(buildStr);
+		}
+	}
+}
+
 int CL_DLLEXPORT Initialize( cl_enginefunc_t *pEnginefuncs, int iVersion )
 {
 	gEngfuncs = *pEnginefuncs;
@@ -161,6 +180,8 @@ int CL_DLLEXPORT Initialize( cl_enginefunc_t *pEnginefuncs, int iVersion )
 		return 0;
 
 	memcpy(&gEngfuncs, pEnginefuncs, sizeof(cl_enginefunc_t));
+
+	SaveEngineVersion();
 
 	update_checker::check_for_updates();
 	discord_integration::initialize();

--- a/cl_dll/cl_util.h
+++ b/cl_dll/cl_util.h
@@ -29,6 +29,16 @@
 #include <stdarg.h>  // "
 #include <string.h> // for strncpy()
 
+#ifdef _WIN32
+#define BUILD_OFFSET_LINUX 0
+#else
+#define BUILD_OFFSET_LINUX 1
+#endif
+
+constexpr int ENGINE_BUILD_ANNIVERSARY_FIRST = 9884 + BUILD_OFFSET_LINUX;
+
+#undef BUILD_OFFSET_LINUX
+
 // Macros to hook function calls into the HUD object
 #define HOOK_MESSAGE(x) gEngfuncs.pfnHookUserMsg(#x, __MsgFunc_##x );
 

--- a/cl_dll/entity.cpp
+++ b/cl_dll/entity.cpp
@@ -21,10 +21,13 @@
 
 #include "particleman.h"
 
+#include "com_model.h"
 #include "r_studioint.h"
 
 #undef min
 #undef max
+
+extern engine_studio_api_t IEngineStudio;
 
 extern IParticleMan *g_pParticleMan;
 
@@ -59,8 +62,14 @@ int CL_DLLEXPORT HUD_AddEntity( int type, struct cl_entity_s *ent, const char *m
 
 	// show triggers that would be transferred from server-side with specific value in renderfx to differ it from other entities
 	// update: there is a new implementation of displaying triggers that allows you to display even when planes is stripped due to optimizations in updated map compiler
-	// so this code will only work if the value 2 is specified in the cvar, but it should not be deleted imo
-	if ((ent->curstate.rendermode == kRenderTransColor) && (ent->curstate.renderfx == kRenderFxTrigger) && (gHUD.m_pShowServerTriggers->value == 2.0f) && !gHUD.IsTriggerForSinglePlayer(ent->curstate.rendercolor))
+	// update 2: we use that code if we know that client is uses software engine and number model surfaces data is available
+	// for hardware engine there is more advanced code that can for example changing alpha per side
+	if ((gHUD.m_pShowServerTriggers->value > 0) &&
+		(!IEngineStudio.IsHardware()) &&
+		(ent->model && ent->model->nummodelsurfaces) &&
+		(ent->curstate.rendermode == kRenderTransColor) &&
+		(ent->curstate.renderfx == kRenderFxTrigger) &&
+		!gHUD.IsTriggerForSinglePlayer(ent->curstate.rendercolor))
 		ent->curstate.renderamt = std::min(255.0f, std::max(0.0f, gHUD.m_pShowServerTriggersAlpha->value));
 
 	// hide corpses option

--- a/cl_dll/hud.h
+++ b/cl_dll/hud.h
@@ -787,6 +787,9 @@ public:
 	bool IsTriggerForSinglePlayer(color24 rendercolor);
 
 	HSPRITE white_sprite = 0;
+
+	char m_szEngineVersion[256];
+	int m_iEngineBuildNumber = -1;
 };
 
 extern CHud gHUD;

--- a/common/com_model.h
+++ b/common/com_model.h
@@ -278,9 +278,20 @@ struct msurface_s
 
 	color24         *samples;               // note: this is the actual lightmap data for this surface
 	decal_t         *pdecals;
-
-	//mdisplaylist_t         displaylist;   // Half-Life 25th Anniversary Update
 };
+#endif
+
+#ifdef __cplusplus
+struct msurface_hw_25th_anniversary_t : public msurface_t
+{
+	mdisplaylist_t displaylist;
+};
+#else
+typedef struct
+{
+	msurface_t surface;
+	mdisplaylist_t displaylist;
+} msurface_hw_25th_anniversary_t;
 #endif
 
 typedef struct


### PR DESCRIPTION
- Inherit `msurface_t` for a new struct in both ways (depends if the file is C or C++)
- Find engine build number from `sv_version` cvar that is declared in engine-side (that code is taken from **BugfixedHL-Rebased**)
- To the message above, `sv_version` outputs information like this: `sv_version "1.1.2.2/Stdio,48,9920"`
- Replace cuboid with polygons drawing for triggers on hardware engine if the model data available, otherwise continue to draw as cuboid

Yes, it turns out there are enough real examples when triggers may not be a cuboid, so drawing with polygons is seem always a matter of time
But as we already know, in map compilers that are not from Valve, as an optimization it's cut off all of that data for unused brush models and therefore that data is not available


Of course that some tools like bspguy can restore that information from a .bsp file, but I don’t I think that we want now to make a large complex work for such minor task 

This code is not completely final, because I’m still thinking about what exactly speed / offset I want to use for change the alpha in these polygons, after this it most likely will be ready for merge, so for now I just made a pull request for a review but not as a merge