### PR TITLE
Remove XP build from Continuous Integration workflow

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,3 +115,10 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-${{ matrix.clang-ver }} g++-multilib libgl-dev ninja-build rapidjson-dev
+          
+      - name: CMake generate
+        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -B build
+
+      - name: Build
+        working-directory: build
+        run: ninja

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,6 +115,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-${{ matrix.clang-ver }} g++-multilib libgl-dev ninja-build rapidjson-dev
+
       - name: CMake generate
         run: cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -B build
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -115,7 +115,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-${{ matrix.clang-ver }} g++-multilib libgl-dev ninja-build rapidjson-dev
-          
       - name: CMake generate
         run: cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -B build
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,8 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { runs-on: windows-2019, toolset: v141_xp }
-          - { runs-on: windows-2022, toolset: v143 }
+          - { runs-on: windows-latest, toolset: v143 }
         configuration: [Release, Debug]
     steps:
       - name: Checkout repository
@@ -52,7 +51,6 @@ jobs:
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
-        if: matrix.config.toolset == 'v141_xp'
         with:
           name: openag-${{ runner.os }}-${{ matrix.configuration }}
           path: build\${{ matrix.configuration }}\client.dll
@@ -117,10 +115,3 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y clang-${{ matrix.clang-ver }} g++-multilib libgl-dev ninja-build rapidjson-dev
-
-      - name: CMake generate
-        run: cmake -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.configuration }} -B build
-
-      - name: Build
-        working-directory: build
-        run: ninja

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,7 +35,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - { runs-on: windows-latest, toolset: v143 }
+          - { runs-on: windows-2022, toolset: v143 }
         configuration: [Release, Debug]
     steps:
       - name: Checkout repository


### PR DESCRIPTION
GitHub Actions has completely deprecated the Windows-2019 image, as well as the v141_xp compilers having been deprecated since VS2017. This has been causing OpenAG's workflows to be considered "failed" for a while now. 

While I doubt anyone needs a Windows XP-compatible version of OpenAG anymore, if one were to really need one, it can easily be built locally.

This PR removes the v141_xp job and sets the v143 job to `windows-latest`. 