### PR TITLE
Fix spectator bottom panel position on high resolutions

### DIFF
--- a/cl_dll/vgui_SpectatorPanel.cpp
+++ b/cl_dll/vgui_SpectatorPanel.cpp
@@ -100,7 +100,9 @@ void SpectatorPanel::Initialize()
 	//m_TopBorder = new CTransparentPanel(255, 0, 0, ScreenWidth, PANEL_HEIGHT);
 	//m_TopBorder->setParent(this);
 
-	m_BottomBorder = new CTransparentPanel(255, 0, ScreenHeight - PANEL_HEIGHT, ScreenWidth, PANEL_HEIGHT);
+	int offset = (ScreenHeight <= 1080) ? 0 : (int)((ScreenHeight - 1080) * 0.06f + 0.5f);
+
+	m_BottomBorder = new CTransparentPanel(255, 0, ScreenHeight - PANEL_HEIGHT - offset, ScreenWidth, PANEL_HEIGHT + offset);
 	m_BottomBorder->setParent(this);
 
 	setPaintBackgroundEnabled(false);


### PR DESCRIPTION
Transparent panel in spectator mode goes off screen on high resolutions. This fix ensures the same visual size and position of the panel for any resolution >1080p based on the size and position for 1080p.

2K
before:
![2k_before](https://github.com/user-attachments/assets/ddcaaefa-1e75-4944-a1e4-31c86f982a84)

after:
![2k_after](https://github.com/user-attachments/assets/c2285300-a959-4d25-a3d2-8300c5cc1e16)

4K
before:
![4k_before](https://github.com/user-attachments/assets/7569a56f-54f5-4ce2-9a8c-cee31b132256)

after:
![4k_after](https://github.com/user-attachments/assets/b3e69306-e2a9-4081-b887-a004c399d428)
